### PR TITLE
Link Note Empathy page to external site

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,13 @@ export default function RootLayout({
               <Link href="/projects">Find Projects</Link>
               <Link href="/organisations">Find Organisations</Link>
               <Link href="/feed">Feed</Link>
-              <Link href="/note-empathy">Note Empathy</Link>
+              <a
+                href="https://note-empathy.org"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Note Empathy
+              </a>
               <Link href="/services">Services</Link>
             </nav>
           </div>

--- a/src/app/note-empathy/page.tsx
+++ b/src/app/note-empathy/page.tsx
@@ -1,4 +1,0 @@
-export default function NoteEmpathyPage() {
-  return <div className="p-6">Note Empathy page placeholder</div>;
-}
-


### PR DESCRIPTION
## Summary
- Replace navigation entry to Note Empathy with external link to note-empathy.org.
- Remove unused Note Empathy page placeholder.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Inter from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68ab18d0a3f083268064eea0168e5f1e