### PR TITLE
Add Supabase client and clean Next.js config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,8 @@
+/** @type {import('next').NextConfig} */
 const nextConfig = {
   experimental: {
-    // Disable built-in font optimization that fetches external Geist fonts
-    optimizePackageImports: [],
-    fontLoaders: [],
+    // remove invalid keys; keep this block if you need other valid flags only
   },
 };
+
 module.exports = nextConfig;

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -3,4 +3,8 @@ import { createClient } from "@supabase/supabase-js";
 const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
 const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
 
+if (!url || !anonKey) {
+  throw new Error("Missing Supabase env vars. Set NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY.");
+}
+
 export const supabase = createClient(url, anonKey);


### PR DESCRIPTION
## Summary
- add Supabase client helper with env var checks
- remove invalid experimental flags from Next.js config

## Testing
- `npm i @supabase/supabase-js`
- `NEXT_PUBLIC_MAPBOX_TOKEN=a NEXT_PUBLIC_SUPABASE_URL=a NEXT_PUBLIC_SUPABASE_ANON_KEY=a npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68ab4254a4a08326a905bfcb8215fc6f