### PR TITLE
feat: add project and watchdog submissions

### DIFF
--- a/src/app/add/project/page.tsx
+++ b/src/app/add/project/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { supabase } from "@/lib/supabase";
+
+export default function AddProjectPage() {
+  const router = useRouter();
+  const [me, setMe] = useState<string | null>(null);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [leadOrgId, setLeadOrgId] = useState<string | null>(null);
+  const [country, setCountry] = useState("");
+  const [thematicArea, setThematicArea] = useState("");
+  const [fundingNeeded, setFundingNeeded] = useState<number | undefined>(undefined);
+  const [statusMsg, setStatusMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      if (!data.user) router.replace("/auth");
+      else setMe(data.user.id);
+    });
+  }, [router]);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!me) return;
+    const { error } = await supabase.from("projects").insert({
+      title,
+      description,
+      lead_org_id: leadOrgId,
+      country,
+      thematic_area: thematicArea,
+      funding_needed: fundingNeeded,
+      review_status: "pending",
+      created_by: me,
+    });
+    if (error) { setStatusMsg(error.message); return; }
+    setStatusMsg("Submitted for review. An admin will approve it.");
+    setTitle(""); setDescription(""); setLeadOrgId(null); setCountry(""); setThematicArea(""); setFundingNeeded(undefined);
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <h1 className="mb-4 text-2xl font-semibold">Add Project</h1>
+      <form onSubmit={submit} className="space-y-3">
+        <input className="w-full rounded-xl border px-3 py-2" placeholder="Project title" value={title} onChange={e=>setTitle(e.target.value)} required />
+        <textarea className="w-full rounded-xl border px-3 py-2" placeholder="Description" value={description} onChange={e=>setDescription(e.target.value)} />
+        <input className="w-full rounded-xl border px-3 py-2" placeholder="Lead organisation ID (optional)" value={leadOrgId ?? ""} onChange={e=>setLeadOrgId(e.target.value || null)} />
+        <div className="flex gap-3">
+          <input className="w-full rounded-xl border px-3 py-2" placeholder="Country" value={country} onChange={e=>setCountry(e.target.value)} />
+          <input className="w-full rounded-xl border px-3 py-2" placeholder="Thematic area" value={thematicArea} onChange={e=>setThematicArea(e.target.value)} />
+        </div>
+        <input type="number" className="w-full rounded-xl border px-3 py-2" placeholder="Funding needed (number)" value={fundingNeeded ?? ""} onChange={e=>setFundingNeeded(e.target.value ? Number(e.target.value) : undefined)} />
+        <button type="submit" className="rounded-xl border px-3 py-2">Submit</button>
+      </form>
+      {statusMsg && <p className="mt-3 text-sm">{statusMsg}</p>}
+      <p className="mt-6 text-xs opacity-70">MVP fields. Extend per blueprint later. Submissions enter pending review.</p>
+    </div>
+  );
+}

--- a/src/app/add/watchdog/page.tsx
+++ b/src/app/add/watchdog/page.tsx
@@ -1,0 +1,49 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { supabase } from "@/lib/supabase";
+
+export default function AddWatchdogPage() {
+  const router = useRouter();
+  const [me, setMe] = useState<string | null>(null);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [country, setCountry] = useState("");
+  const [statusMsg, setStatusMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      if (!data.user) router.replace("/auth");
+      else setMe(data.user.id);
+    });
+  }, [router]);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!me) return;
+    const { error } = await supabase.from("watchdog_cases").insert({
+      title,
+      description,
+      country,
+      review_status: "pending",
+      created_by: me,
+    });
+    if (error) { setStatusMsg(error.message); return; }
+    setStatusMsg("Submitted for review. An admin will approve it.");
+    setTitle(""); setDescription(""); setCountry("");
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl p-6">
+      <h1 className="mb-4 text-2xl font-semibold">Add Watchdog Case</h1>
+      <form onSubmit={submit} className="space-y-3">
+        <input className="w-full rounded-xl border px-3 py-2" placeholder="Case title" value={title} onChange={e=>setTitle(e.target.value)} required />
+        <textarea className="w-full rounded-xl border px-3 py-2" placeholder="Description" value={description} onChange={e=>setDescription(e.target.value)} />
+        <input className="w-full rounded-xl border px-3 py-2" placeholder="Country" value={country} onChange={e=>setCountry(e.target.value)} />
+        <button type="submit" className="rounded-xl border px-3 py-2">Submit</button>
+      </form>
+      {statusMsg && <p className="mt-3 text-sm">{statusMsg}</p>}
+      <p className="mt-6 text-xs opacity-70">MVP fields. Extend per blueprint later. Submissions enter pending review.</p>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,7 @@
 import "./globals.css";
 import type { Metadata } from "next";
 import { ReactNode } from "react";
-import AuthButton from "@/components/AuthButton";
-import Link from "next/link";
+import TopNav from "@/components/TopNav";
 
 export const metadata: Metadata = {
   title: "Solarpunk Taskforce",
@@ -13,13 +12,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body className="min-h-screen">
-        <header className="flex items-center justify-between px-6 py-3">
-          <Link href="/" className="text-lg font-semibold">Solarpunk Taskforce</Link>
-          <div className="flex items-center gap-4">
-            {/* existing nav here */}
-            <AuthButton />
-          </div>
-        </header>
+        <TopNav />
         {children}
       </body>
     </html>

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -1,0 +1,71 @@
+"use client";
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { supabase } from "@/lib/supabase";
+import AddAction from "@/components/add/AddAction";
+
+type Profile = {
+  id: string;
+  kind: "individual" | "organisation";
+  full_name: string | null;
+  surname: string | null;
+  organisation_name: string | null;
+};
+
+function initials(p: Profile | null) {
+  if (!p) return "•";
+  if (p.kind === "organisation") return (p.organisation_name ?? "Org").slice(0, 2).toUpperCase();
+  const name = [p.full_name, p.surname].filter(Boolean).join(" ");
+  return name ? name.split(" ").map(s => s[0]).slice(0, 2).join("").toUpperCase() : "U";
+}
+
+export default function TopNav() {
+  const [sessionUserId, setSessionUserId] = useState<string | null>(null);
+  const [profile, setProfile] = useState<Profile | null>(null);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => setSessionUserId(data.user?.id ?? null));
+    const { data: sub } = supabase.auth.onAuthStateChange((_e, s) => setSessionUserId(s?.user?.id ?? null));
+    return () => sub.subscription.unsubscribe();
+  }, []);
+
+  useEffect(() => {
+    if (!sessionUserId) { setProfile(null); return; }
+    supabase
+      .from("profiles")
+      .select("id, kind, full_name, surname, organisation_name")
+      .eq("id", sessionUserId)
+      .single()
+      .then(({ data }) => setProfile(data as Profile));
+  }, [sessionUserId]);
+
+  const navLinks = useMemo(() => ([
+    { href: "/about", label: "About" },
+    { href: "/find-projects", label: "Find Projects" },
+    { href: "/find-organisations", label: "Find Organisations" },
+    { href: "/feed", label: "Feed" },
+    { href: "/note-empathy", label: "Note Empathy" },
+    { href: "/services", label: "Services" },
+  ]), []);
+
+  return (
+    <header className="flex items-center justify-between px-6 py-3">
+      <Link href="/" className="text-lg font-semibold">Solarpunk Taskforce</Link>
+      <nav className="hidden gap-5 md:flex">
+        {navLinks.map(l => (
+          <Link key={l.href} href={l.href} className="text-sm hover:underline">{l.label}</Link>
+        ))}
+      </nav>
+      <div className="flex items-center gap-3">
+        {profile && <AddAction accountKind={profile.kind} />}
+        {profile ? (
+          <Link href="/dashboard" className="grid h-9 w-9 place-items-center rounded-full border text-xs">
+            {initials(profile)}
+          </Link>
+        ) : (
+          <Link href="/auth" className="rounded-xl border px-3 py-1 text-sm">Sign in</Link>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/src/components/add/AddAction.tsx
+++ b/src/components/add/AddAction.tsx
@@ -1,0 +1,31 @@
+"use client";
+import Link from "next/link";
+import { useMemo } from "react";
+
+/**
+ * Circular + button that on hover slides left to reveal text.
+ * Org → "Add Project" → /add/project
+ * Individual → "Add Watchdog Case" → /add/watchdog
+ */
+export default function AddAction({ accountKind }: { accountKind: "individual" | "organisation" }) {
+  const conf = useMemo(() => {
+    return accountKind === "organisation"
+      ? { href: "/add/project", label: "Add Project" }
+      : { href: "/add/watchdog", label: "Add Watchdog Case" };
+  }, [accountKind]);
+
+  return (
+    <Link
+      href={conf.href}
+      className="group relative flex items-center overflow-hidden"
+      aria-label={conf.label}
+    >
+      <span className="grid h-9 w-9 place-items-center rounded-full border transition-transform duration-200 group-hover:-translate-x-[6.5rem]">
+        +
+      </span>
+      <span className="pointer-events-none absolute left-0 ml-11 whitespace-nowrap text-sm opacity-0 transition-all duration-200 group-hover:ml-3 group-hover:opacity-100">
+        {conf.label}
+      </span>
+    </Link>
+  );
+}

--- a/supabase/migrations/20250825110000_add_submissions_and_admin.sql
+++ b/supabase/migrations/20250825110000_add_submissions_and_admin.sql
@@ -1,0 +1,93 @@
+-- add is_admin to profiles
+alter table public.profiles add column if not exists is_admin boolean default false;
+
+-- projects table (MVP fields; extend later)
+create table if not exists public.projects (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  description text,
+  links jsonb,
+  lead_org_id uuid references public.organisations(id) on delete set null,
+  partner_org_ids uuid[],
+  country text,
+  region text,
+  lat double precision,
+  lng double precision,
+  intervention_type text,
+  target_demographics text[],
+  lives_improved integer,
+  start_date date,
+  end_date date,
+  thematic_area text,
+  sdgs text[],
+  ifrc_global_challenges text[],
+  donations_received numeric default 0,
+  funding_needed numeric,
+  status text not null default 'planned' check (status in ('planned','active','completed')),
+  review_status text not null default 'pending' check (review_status in ('pending','approved','rejected')),
+  created_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz default now()
+);
+alter table public.projects enable row level security;
+
+-- watchdog cases table (MVP fields; extend later)
+create table if not exists public.watchdog_cases (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  description text,
+  location text,
+  country text,
+  region text,
+  lat double precision,
+  lng double precision,
+  target_demographics text[],
+  links jsonb,
+  sdgs text[],
+  ifrc_global_challenges text[],
+  review_status text not null default 'pending' check (review_status in ('pending','approved','rejected')),
+  created_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz default now()
+);
+alter table public.watchdog_cases enable row level security;
+
+-- helper: check admin flag on profile
+create or replace function public.is_admin(uid uuid)
+returns boolean language sql stable as $$
+  select coalesce((select is_admin from public.profiles p where p.id = uid), false)
+$$;
+
+-- RLS for projects
+drop policy if exists "projects_public_read_approved_or_owner" on public.projects;
+create policy "projects_public_read_approved_or_owner" on public.projects
+for select using ( review_status = 'approved' or auth.uid() = created_by );
+
+drop policy if exists "projects_insert_auth" on public.projects;
+create policy "projects_insert_auth" on public.projects
+for insert to authenticated with check ( auth.uid() = created_by );
+
+drop policy if exists "projects_update_owner_while_pending" on public.projects;
+create policy "projects_update_owner_while_pending" on public.projects
+for update using ( auth.uid() = created_by and review_status = 'pending' )
+with check ( auth.uid() = created_by );
+
+drop policy if exists "projects_admin_update" on public.projects;
+create policy "projects_admin_update" on public.projects
+for update using ( public.is_admin(auth.uid()) ) with check ( true );
+
+-- RLS for watchdog_cases
+drop policy if exists "wd_public_read_approved_or_owner" on public.watchdog_cases;
+create policy "wd_public_read_approved_or_owner" on public.watchdog_cases
+for select using ( review_status = 'approved' or auth.uid() = created_by );
+
+drop policy if exists "wd_insert_auth" on public.watchdog_cases;
+create policy "wd_insert_auth" on public.watchdog_cases
+for insert to authenticated with check ( auth.uid() = created_by );
+
+drop policy if exists "wd_update_owner_while_pending" on public.watchdog_cases;
+create policy "wd_update_owner_while_pending" on public.watchdog_cases
+for update using ( auth.uid() = created_by and review_status = 'pending' )
+with check ( auth.uid() = created_by );
+
+drop policy if exists "wd_admin_update" on public.watchdog_cases;
+create policy "wd_admin_update" on public.watchdog_cases
+for update using ( public.is_admin(auth.uid()) ) with check ( true );


### PR DESCRIPTION
## Summary
- add top navigation with profile avatar and add-action button
- support project and watchdog case submissions pending admin review
- define projects and watchdog_cases tables with review policies

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac1edde5b48326a6c42ab7d8544670