### PR TITLE
Handle auth errors and session redirects

### DIFF
--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -12,18 +12,26 @@ export default function AuthPage() {
   const [orgName, setOrgName] = useState("");
   const [loading, setLoading] = useState(false);
   const [msg, setMsg] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "";
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setLoading(true);
     setMsg(null);
+    setErrorMsg(null);
 
     try {
       if (mode === "signin") {
-        const { error } = await supabase.auth.signInWithPassword({ email, password });
-        if (error) throw error;
-        router.replace("/"); router.refresh();
+        const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+        if (error) {
+          setErrorMsg(error.message);
+          return;
+        }
+        if (data.session) {
+          router.replace("/");
+          router.refresh();
+        }
         return;
       }
 
@@ -68,7 +76,7 @@ export default function AuthPage() {
         setMsg("Check your email to confirm the account, then sign in.");
       }
     } catch (err: unknown) {
-      setMsg(err instanceof Error ? err.message : "Error");
+      setErrorMsg(err instanceof Error ? err.message : "Error");
     } finally {
       setLoading(false);
     }
@@ -146,6 +154,7 @@ export default function AuthPage() {
         </button>
       </form>
 
+      {errorMsg && <p className="mt-3 text-sm font-semibold text-red-600">{errorMsg}</p>}
       {msg && <p className="mt-3 text-sm">{msg}</p>}
     </div>
   );


### PR DESCRIPTION
## Summary
- Show Supabase sign-in errors to the user
- Redirect after sign-in only when a session exists

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `NEXT_PUBLIC_MAPBOX_TOKEN=test NEXT_PUBLIC_SUPABASE_URL=https://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=anon npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adbff1242083269be687210a57c7ad