### PR TITLE
fix: ensure map renders on client and update navigation

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,15 @@
-import Map from "@/components/Map";
+"use client";
 
-export default function Home() {
+import dynamic from "next/dynamic";
+
+const Map = dynamic(() => import("@/components/Map"), { ssr: false });
+
+export default function HomePage() {
   return (
-    <div className="h-[calc(100vh-3.5rem)]">
-      <Map />
-    </div>
+    <main className="p-4">
+      <div className="mb-4 text-xl font-semibold">Solarpunk Taskforce</div>
+      <Map markers={[]} />
+    </main>
   );
 }
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+
+export default function Header() {
+  return (
+    <header className="flex items-center justify-between p-3">
+      <Link href="/" className="text-lg font-bold" aria-label="Home">
+        Solarpunk
+      </Link>
+      <nav className="flex gap-4">
+        <Link href="/" prefetch={false}>Home</Link>
+        <Link href="/projects" prefetch={false}>Projects</Link>
+      </nav>
+    </header>
+  );
+}
+


### PR DESCRIPTION
## Summary
- force client-side rendering of Map on the Home page
- add Map component cleanup and marker support with Mapbox CSS import
- use `next/link` in Header navigation for Home and Projects

## Testing
- ⚠️ `npm test` *(missing script)*
- ✅ `npm run lint`
- ⚠️ `npm run dev` *(started with placeholder env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68af08bb12cc8326909d46ec4ac144f5