### PR TITLE
feat: add project approval flow

### DIFF
--- a/src/app/(public)/map/page.tsx
+++ b/src/app/(public)/map/page.tsx
@@ -1,0 +1,17 @@
+import Map from "@/components/Map";
+import { supabase } from "@/lib/supabase";
+
+export default async function MapPage() {
+  const { data, error } = await supabase
+    .from("projects")
+    .select("id, title, lat, lng")
+    .eq("status", "approved");
+
+  if (error) {
+    // Fail closed: empty markers
+    return <Map markers={[]} />;
+  }
+
+  const markers = (data ?? []).map(p => ({ id: p.id, title: p.title, lat: p.lat, lng: p.lng }));
+  return <Map markers={markers} />;
+}

--- a/src/app/api/projects/[id]/approve/route.ts
+++ b/src/app/api/projects/[id]/approve/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { cookies } from "next/headers";
+
+export async function POST(_: NextRequest, { params }: { params: { id: string } }) {
+  const id = params.id;
+
+  // make supabase client bound to cookies so RLS sees auth
+  const cookieStore = cookies();
+  cookieStore.getAll();
+  const { data: { user }, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !user) return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+
+  const { error } = await supabase
+    .from("projects")
+    .update({ status: "approved", approved_by: user.id, approved_at: new Date().toISOString() })
+    .eq("id", id);
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const { title, description, lat, lng, org_name } = body ?? {};
+
+  // Get user session via auth header cookie
+  const { data: { user }, error: userErr } = await supabase.auth.getUser();
+  if (userErr || !user) return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+
+  const { error } = await supabase.from("projects").insert({
+    title, description, lat, lng, org_name,
+    created_by: user.id,
+    status: "pending"
+  });
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+  return NextResponse.json({ ok: true, status: "pending" });
+}

--- a/supabase/migrations/20250828_roles_projects.sql
+++ b/supabase/migrations/20250828_roles_projects.sql
@@ -1,0 +1,103 @@
+-- enums
+create type user_role as enum ('admin','member');
+create type project_status as enum ('pending','approved','rejected');
+
+-- profiles linked to auth.users
+create table if not exists public.profiles (
+  id uuid primary key references auth.users(id) on delete cascade,
+  username text unique,
+  role user_role not null default 'member',
+  created_at timestamptz not null default now()
+);
+
+alter table public.profiles enable row level security;
+
+create policy "profiles_self_read" on public.profiles
+for select using (auth.uid() = id);
+
+create policy "profiles_self_update" on public.profiles
+for update using (auth.uid() = id)
+with check (auth.uid() = id);
+
+create policy "profiles_public_read_admin_only" on public.profiles
+for select using (exists (select 1 from public.profiles p where p.id = auth.uid() and p.role = 'admin'));
+
+-- projects
+create table if not exists public.projects (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  description text,
+  lat double precision not null,
+  lng double precision not null,
+  org_name text,
+  status project_status not null default 'pending',
+  created_by uuid not null references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  approved_by uuid references auth.users(id),
+  approved_at timestamptz
+);
+
+alter table public.projects enable row level security;
+
+-- Public can read only approved
+create policy "projects_public_read_approved_only" on public.projects
+for select using (status = 'approved');
+
+-- Creators can read their own pending/rejected
+create policy "projects_creator_read_own" on public.projects
+for select using (auth.uid() = created_by);
+
+-- Creators can insert pending items only for themselves
+create policy "projects_creator_insert_pending" on public.projects
+for insert to authenticated
+with check (
+  auth.uid() = created_by
+  and status = 'pending'
+);
+
+-- Creators can update their own pending items (not status/approval fields)
+create policy "projects_creator_update_pending_own" on public.projects
+for update to authenticated
+using (auth.uid() = created_by and status = 'pending')
+with check (
+  auth.uid() = created_by
+  and status = 'pending'
+);
+
+-- Admin approval policy: only admins can set status and approval fields
+create or replace function public.is_admin(uid uuid) returns boolean
+language sql stable as $$
+  select exists(
+    select 1 from public.profiles where id = uid and role = 'admin'
+  );
+$$;
+
+create policy "projects_admin_full_access" on public.projects
+for all to authenticated
+using (public.is_admin(auth.uid()))
+with check (public.is_admin(auth.uid()));
+
+-- Prevent non-admin edits of status/approval via column-level security-ish trigger
+create or replace function public.enforce_status_changes()
+returns trigger language plpgsql as $$
+begin
+  if (tg_op = 'UPDATE') then
+    if (new.status <> old.status or new.approved_by is distinct from old.approved_by or new.approved_at is distinct from old.approved_at) then
+      if not public.is_admin(auth.uid()) then
+        raise exception 'only admins can change approval fields';
+      end if;
+    end if;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_enforce_status on public.projects;
+create trigger trg_enforce_status
+before update on public.projects
+for each row execute function public.enforce_status_changes();
+
+-- Helpful indexes
+create index if not exists projects_status_idx on public.projects(status);
+create index if not exists projects_coords_idx on public.projects (lat, lng);
+create index if not exists projects_created_by_idx on public.projects(created_by);


### PR DESCRIPTION
## Summary
- add roles and project status migrations with RLS and indexes
- expose project creation and approval API routes
- show only approved projects on map page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b01c12036c83269f50a133b5c7d612