### PR TITLE
refactor: update route context parameter

### DIFF
--- a/src/app/api/projects/[id]/approve/route.ts
+++ b/src/app/api/projects/[id]/approve/route.ts
@@ -2,8 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/lib/supabase";
 import { cookies } from "next/headers";
 
-export async function POST(_: NextRequest, { params }: { params: { id: string } }) {
-  const id = params.id;
+export async function POST(_: NextRequest, context: { params: { id: string } }) {
+  const { id } = context.params;
 
   // make supabase client bound to cookies so RLS sees auth
   const cookieStore = cookies();


### PR DESCRIPTION
## Summary
- refactor API project approval endpoint to use route context param object

## Testing
- `npm run build` *(fails: Route has an invalid "POST" export)*

------
https://chatgpt.com/codex/tasks/task_e_68b0630c0f8c8326a1cde4cd887e0ff4