### PR TITLE
feat: extend project submission

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,13 +10,17 @@
     "db:sync": "scripts/db-sync.sh"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.1",
+    "@mapbox/mapbox-gl-geocoder": "^5.1.2",
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.56.0",
     "lucide-react": "^0.542.0",
     "mapbox-gl": "^3.14.0",
     "next": "15.4.7",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "react-hook-form": "^7.62.0",
+    "zod": "^4.1.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.2.1
+        version: 5.2.1(react-hook-form@7.62.0(react@19.1.0))
+      '@mapbox/mapbox-gl-geocoder':
+        specifier: ^5.1.2
+        version: 5.1.2
       '@supabase/ssr':
         specifier: ^0.7.0
         version: 0.7.0(@supabase/supabase-js@2.56.0)
@@ -29,6 +35,12 @@ importers:
       react-dom:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
+      react-hook-form:
+        specifier: ^7.62.0
+        version: 7.62.0(react@19.1.0)
+      zod:
+        specifier: ^4.1.5
+        version: 4.1.5
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
@@ -66,6 +78,14 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@babel/code-frame@7.27.1':
+    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
 
   '@emnapi/core@1.4.5':
     resolution: {integrity: sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==}
@@ -113,6 +133,11 @@ packages:
   '@eslint/plugin-kit@0.3.5':
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@hookform/resolvers@5.2.1':
+    resolution: {integrity: sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -276,15 +301,33 @@ packages:
   '@jridgewell/trace-mapping@0.3.30':
     resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
 
+  '@mapbox/fusspot@0.4.0':
+    resolution: {integrity: sha512-6sys1vUlhNCqMvJOqPEPSi0jc9tg7aJ//oG1A16H3PXoIt9whtNngD7UzBHUVTH15zunR/vRvMtGNVsogm1KzA==}
+
   '@mapbox/jsonlint-lines-primitives@2.0.2':
     resolution: {integrity: sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==}
     engines: {node: '>= 0.6'}
 
+  '@mapbox/mapbox-gl-geocoder@5.1.2':
+    resolution: {integrity: sha512-UjtGKL/bfaUTf4NfDaKCeYIvtMIJi9nr94QQB13p8uPXhSfjo931zhWNAib3YY7xkNqzVEBWzFGuB1IT5w7lGA==}
+    engines: {node: '>=6'}
+
   '@mapbox/mapbox-gl-supported@3.0.0':
     resolution: {integrity: sha512-2XghOwu16ZwPJLOFVuIOaLbN0iKMn867evzXFyf0P22dqugezfJwLmdanAgU25ITvz1TvOfVP4jsDImlDJzcWg==}
 
+  '@mapbox/mapbox-sdk@0.16.1':
+    resolution: {integrity: sha512-dyZrmg+UL/Gp5mGG3CDbcwGSUMYYrfbd9hdp0rcA3pHSf3A9eYoXO9nFiIk6SzBwBVMzHENJz84ZHdqM0MDncQ==}
+    engines: {node: '>=6'}
+
+  '@mapbox/parse-mapbox-token@0.2.0':
+    resolution: {integrity: sha512-BjeuG4sodYaoTygwXIuAWlZV6zUv4ZriYAQhXikzx+7DChycMUQ9g85E79Htat+AsBg+nStFALehlOhClYm5cQ==}
+
   '@mapbox/point-geometry@1.1.0':
     resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
+
+  '@mapbox/polyline@1.2.1':
+    resolution: {integrity: sha512-sn0V18O3OzW4RCcPoUIVDWvEGQaBNH9a0y5lgqrf5hUycyw1CzrhEoxV5irzrMNXKCkw1xRsZXcaVbsVZggHXA==}
+    hasBin: true
 
   '@mapbox/tiny-sdf@2.0.7':
     resolution: {integrity: sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==}
@@ -378,6 +421,13 @@ packages:
   '@rushstack/eslint-patch@1.12.0':
     resolution: {integrity: sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==}
 
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
   '@supabase/auth-js@2.71.1':
     resolution: {integrity: sha512-mMIQHBRc+SKpZFRB2qtupuzulaUhFYupNyxqDj5Jp/LyPvcWvjaJzZzObv6URtL/O6lPxkanASnotGtNpS3H2Q==}
 
@@ -407,6 +457,10 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@szmarczak/http-timer@4.0.6':
+    resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
+    engines: {node: '>=10'}
 
   '@tailwindcss/node@4.1.12':
     resolution: {integrity: sha512-3hm9brwvQkZFe++SBt+oLjo4OLDtkvlE8q2WalaD/7QWaeM7KEJbAiY/LJZUaCs7Xa8aUu4xy3uoyX4q54UVdQ==}
@@ -499,6 +553,9 @@ packages:
   '@tybys/wasm-util@0.10.0':
     resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
 
+  '@types/cacheable-request@6.0.3':
+    resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -508,17 +565,29 @@ packages:
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
+  '@types/http-cache-semantics@4.0.4':
+    resolution: {integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
+  '@types/keyv@3.1.4':
+    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
+
   '@types/mapbox__point-geometry@0.1.4':
     resolution: {integrity: sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==}
 
+  '@types/minimist@1.2.5':
+    resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
+
   '@types/node@20.19.11':
     resolution: {integrity: sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==}
+
+  '@types/normalize-package-data@2.4.4':
+    resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
   '@types/pbf@3.0.5':
     resolution: {integrity: sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==}
@@ -533,6 +602,9 @@ packages:
 
   '@types/react@19.1.12':
     resolution: {integrity: sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==}
+
+  '@types/responselike@1.0.3':
+    resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
   '@types/supercluster@7.1.3':
     resolution: {integrity: sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==}
@@ -754,12 +826,19 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  arrify@1.0.1:
+    resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
+    engines: {node: '>=0.10.0'}
+
   ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
 
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -776,6 +855,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base-64@0.1.0:
+    resolution: {integrity: sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==}
+
   bin-links@5.0.0:
     resolution: {integrity: sha512-sdleLVfCjBtgO5cNjA2HVRvWBJAHs4zwenaCPMNJAJU0yNxpzj80IpjOIimkpkr+mhlA+how5poQtt53PygbHA==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -788,6 +870,14 @@ packages:
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  cacheable-lookup@5.0.4:
+    resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
+    engines: {node: '>=10.6.0'}
+
+  cacheable-request@7.0.4:
+    resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
     engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
@@ -804,6 +894,14 @@ packages:
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
+    engines: {node: '>=6'}
+
+  camelcase-keys@6.2.2:
+    resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
+    engines: {node: '>=8'}
+
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
 
   caniuse-lite@1.0.30001737:
@@ -823,6 +921,9 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  clone-response@1.0.3:
+    resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
+
   cmd-shim@7.0.0:
     resolution: {integrity: sha512-rtpaCbr164TPPh+zFdkWpCyZuKkjpAzODfaZCf/SVJZzJN+4bHQb/LP3Jzq5/+84um3XXY8r548XiWKSborwVw==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -840,6 +941,10 @@ packages:
   color@4.2.3:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -894,8 +999,24 @@ packages:
       supports-color:
         optional: true
 
+  decamelize-keys@1.1.1:
+    resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
+    engines: {node: '>=0.10.0'}
+
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  defer-to-connect@2.0.1:
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
+    engines: {node: '>=10'}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -904,6 +1025,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
@@ -923,9 +1048,15 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
     engines: {node: '>=10.13.0'}
+
+  error-ex@1.3.2:
+    resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
 
   es-abstract@1.24.0:
     resolution: {integrity: sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==}
@@ -1079,6 +1210,13 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@3.1.2:
+    resolution: {integrity: sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==}
+
+  events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1120,6 +1258,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -1135,6 +1277,10 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  form-data@3.0.4:
+    resolution: {integrity: sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==}
+    engines: {node: '>= 6'}
+
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
@@ -1149,6 +1295,10 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
+  fuzzy@0.1.3:
+    resolution: {integrity: sha512-/gZffu4ykarLrCiP3Ygsa86UAo1E5vEVlvTrpkKywXSbP9Xhln3oSp9QSV57gEq3JFFpGJ4GZ+5zdEp3FcUh4w==}
+    engines: {node: '>= 0.6.0'}
+
   geojson-vt@4.0.2:
     resolution: {integrity: sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==}
 
@@ -1159,6 +1309,10 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
 
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
@@ -1190,6 +1344,10 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  got@11.8.6:
+    resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
+    engines: {node: '>=10.19.0'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -1198,6 +1356,10 @@ packages:
 
   grid-index@1.1.0:
     resolution: {integrity: sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==}
+
+  hard-rejection@2.1.0:
+    resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
+    engines: {node: '>=6'}
 
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
@@ -1226,6 +1388,20 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hosted-git-info@2.8.9:
+    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
+
+  hosted-git-info@4.1.0:
+    resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
+    engines: {node: '>=10'}
+
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http2-wrapper@1.0.3:
+    resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
+    engines: {node: '>=10.19.0'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -1246,6 +1422,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -1253,6 +1433,9 @@ packages:
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-arrayish@0.3.2:
     resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
@@ -1320,6 +1503,10 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-plain-obj@1.1.0:
+    resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
+    engines: {node: '>=0.10.0'}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -1380,6 +1567,9 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -1399,6 +1589,10 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -1475,9 +1669,19 @@ packages:
     resolution: {integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==}
     engines: {node: '>= 12.0.0'}
 
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash.debounce@4.0.8:
+    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -1486,6 +1690,14 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lowercase-keys@2.0.0:
+    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
+    engines: {node: '>=8'}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+
   lucide-react@0.542.0:
     resolution: {integrity: sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw==}
     peerDependencies:
@@ -1493,6 +1705,14 @@ packages:
 
   magic-string@0.30.18:
     resolution: {integrity: sha512-yi8swmWbO17qHhwIBNeeZxTceJMeBvWJaId6dyvTSOwTipqeHhMhOrz6513r1sOKnpvQ7zkhlG8tPrpilwTxHQ==}
+
+  map-obj@1.0.1:
+    resolution: {integrity: sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==}
+    engines: {node: '>=0.10.0'}
+
+  map-obj@4.3.0:
+    resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
+    engines: {node: '>=8'}
 
   mapbox-gl@3.14.0:
     resolution: {integrity: sha512-KYhi9ZOQL4BB0J061admPH8O5ZZhhxsyiJ6DQCOkCaps0JEB4HF3SbJwu8S0pJKaQUxNS33sSbzW8iDSSauHPQ==}
@@ -1504,6 +1724,10 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  meow@9.0.0:
+    resolution: {integrity: sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==}
+    engines: {node: '>=10'}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1512,12 +1736,36 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mimic-response@1.0.1:
+    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
+    engines: {node: '>=4'}
+
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minimist-options@4.1.0:
+    resolution: {integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==}
+    engines: {node: '>= 6'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -1584,6 +1832,17 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  normalize-package-data@2.5.0:
+    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
+
+  normalize-package-data@3.0.3:
+    resolution: {integrity: sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==}
+    engines: {node: '>=10'}
+
+  normalize-url@6.1.0:
+    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
+    engines: {node: '>=10'}
+
   npm-normalize-package-bin@4.0.0:
     resolution: {integrity: sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -1620,6 +1879,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1628,17 +1890,37 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  p-cancelable@2.1.1:
+    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
+    engines: {node: '>=8'}
+
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -1695,12 +1977,23 @@ packages:
   protocol-buffers-schema@3.6.0:
     resolution: {integrity: sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==}
 
+  pump@3.0.3:
+    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-lru@4.0.1:
+    resolution: {integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==}
+    engines: {node: '>=8'}
+
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
 
   quickselect@3.0.0:
     resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
@@ -1709,6 +2002,12 @@ packages:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
       react: ^19.1.0
+
+  react-hook-form@7.62.0:
+    resolution: {integrity: sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -1721,6 +2020,18 @@ packages:
     resolution: {integrity: sha512-SEbJV7tohp3DAAILbEMPXavBjAnMN0tVnh4+9G8ihV4Pq3HYF9h8QNez9zkJ1ILkv9G2BjdzwctznGZXgu/HGw==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  read-pkg-up@7.0.1:
+    resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
+    engines: {node: '>=8'}
+
+  read-pkg@5.2.0:
+    resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
+    engines: {node: '>=8'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
@@ -1728,6 +2039,9 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  resolve-alpn@1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1747,6 +2061,9 @@ packages:
   resolve@2.0.0-next.5:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
+
+  responselike@2.0.1:
+    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -1772,6 +2089,10 @@ packages:
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -1837,6 +2158,18 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+
+  spdx-license-ids@3.0.22:
+    resolution: {integrity: sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==}
+
   splaytree@0.1.4:
     resolution: {integrity: sha512-D50hKrjZgBzqD3FT2Ek53f2dcDLAQT8SSGrzj3vidNH5ISRgceeGVJ2dQIthKOuayqFXfFjXheHNo4bbt9LhRQ==}
 
@@ -1874,6 +2207,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -1890,6 +2227,12 @@ packages:
         optional: true
       babel-plugin-macros:
         optional: true
+
+  subtag@0.5.0:
+    resolution: {integrity: sha512-CaIBcTSb/nyk4xiiSOtZYz1B+F12ZxW8NEp54CdT+84vmh/h4sUnHGC6+KQXUfED8u22PQjCYWfZny8d2ELXwg==}
+
+  suggestions@1.7.1:
+    resolution: {integrity: sha512-gl5YPAhPYl07JZ5obiD9nTZsg4SyZswAQU/NNtnYiSnFkI3+ZHuXAiEsYm7AaZ71E0LXSFaGVaulGSWN3Gd71A==}
 
   supabase@2.39.2:
     resolution: {integrity: sha512-/LDPMDIDmuDwj3UsKVw+wA+uHF7QhEF8xgJnKpnk1vqVdr+lA6xRSwWQzgaNuwPj5YPt6+78JKp+wzKziTsRVw==}
@@ -1935,6 +2278,10 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
+  trim-newlines@3.0.1:
+    resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
+    engines: {node: '>=8'}
+
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
     engines: {node: '>=18.12'}
@@ -1950,6 +2297,18 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@0.18.1:
+    resolution: {integrity: sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==}
+    engines: {node: '>=10'}
+
+  type-fest@0.6.0:
+    resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
+    engines: {node: '>=8'}
+
+  type-fest@0.8.1:
+    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
+    engines: {node: '>=8'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -1984,6 +2343,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  validate-npm-package-license@3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -2020,6 +2382,9 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   write-file-atomic@6.0.0:
     resolution: {integrity: sha512-GmqrO8WJ1NuzJ2DrziEI2o57jKAVIQNf8a18W3nCYU3H7PNWqCCVTeH6/NQE93CIllIgQS98rrmVkYgTX9fFJQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -2036,17 +2401,39 @@ packages:
       utf-8-validate:
         optional: true
 
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@4.1.5:
+    resolution: {integrity: sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@babel/code-frame@7.27.1':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.27.1
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.27.1': {}
 
   '@emnapi/core@1.4.5':
     dependencies:
@@ -2107,6 +2494,11 @@ snapshots:
     dependencies:
       '@eslint/core': 0.15.2
       levn: 0.4.1
+
+  '@hookform/resolvers@5.2.1(react-hook-form@7.62.0(react@19.1.0))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.62.0(react@19.1.0)
 
   '@humanfs/core@0.19.1': {}
 
@@ -2230,11 +2622,45 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mapbox/fusspot@0.4.0':
+    dependencies:
+      is-plain-obj: 1.1.0
+      xtend: 4.0.2
+
   '@mapbox/jsonlint-lines-primitives@2.0.2': {}
+
+  '@mapbox/mapbox-gl-geocoder@5.1.2':
+    dependencies:
+      '@mapbox/mapbox-sdk': 0.16.1
+      events: 3.3.0
+      lodash.debounce: 4.0.8
+      nanoid: 3.3.11
+      subtag: 0.5.0
+      suggestions: 1.7.1
+      xtend: 4.0.2
 
   '@mapbox/mapbox-gl-supported@3.0.0': {}
 
+  '@mapbox/mapbox-sdk@0.16.1':
+    dependencies:
+      '@mapbox/fusspot': 0.4.0
+      '@mapbox/parse-mapbox-token': 0.2.0
+      '@mapbox/polyline': 1.2.1
+      eventemitter3: 3.1.2
+      form-data: 3.0.4
+      got: 11.8.6
+      is-plain-obj: 1.1.0
+      xtend: 4.0.2
+
+  '@mapbox/parse-mapbox-token@0.2.0':
+    dependencies:
+      base-64: 0.1.0
+
   '@mapbox/point-geometry@1.1.0': {}
+
+  '@mapbox/polyline@1.2.1':
+    dependencies:
+      meow: 9.0.0
 
   '@mapbox/tiny-sdf@2.0.7': {}
 
@@ -2303,6 +2729,10 @@ snapshots:
 
   '@rushstack/eslint-patch@1.12.0': {}
 
+  '@sindresorhus/is@4.6.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
+
   '@supabase/auth-js@2.71.1':
     dependencies:
       '@supabase/node-fetch': 2.6.15
@@ -2353,6 +2783,10 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@szmarczak/http-timer@4.0.6':
+    dependencies:
+      defer-to-connect: 2.0.1
 
   '@tailwindcss/node@4.1.12':
     dependencies:
@@ -2431,6 +2865,13 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/cacheable-request@6.0.3':
+    dependencies:
+      '@types/http-cache-semantics': 4.0.4
+      '@types/keyv': 3.1.4
+      '@types/node': 20.19.11
+      '@types/responselike': 1.0.3
+
   '@types/estree@1.0.8': {}
 
   '@types/geojson-vt@3.2.5':
@@ -2439,15 +2880,25 @@ snapshots:
 
   '@types/geojson@7946.0.16': {}
 
+  '@types/http-cache-semantics@4.0.4': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
 
+  '@types/keyv@3.1.4':
+    dependencies:
+      '@types/node': 20.19.11
+
   '@types/mapbox__point-geometry@0.1.4': {}
+
+  '@types/minimist@1.2.5': {}
 
   '@types/node@20.19.11':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/normalize-package-data@2.4.4': {}
 
   '@types/pbf@3.0.5': {}
 
@@ -2460,6 +2911,10 @@ snapshots:
   '@types/react@19.1.12':
     dependencies:
       csstype: 3.1.3
+
+  '@types/responselike@1.0.3':
+    dependencies:
+      '@types/node': 20.19.11
 
   '@types/supercluster@7.1.3':
     dependencies:
@@ -2711,9 +3166,13 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  arrify@1.0.1: {}
+
   ast-types-flow@0.0.8: {}
 
   async-function@1.0.0: {}
+
+  asynckit@0.4.0: {}
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -2724,6 +3183,8 @@ snapshots:
   axobject-query@4.1.0: {}
 
   balanced-match@1.0.2: {}
+
+  base-64@0.1.0: {}
 
   bin-links@5.0.0:
     dependencies:
@@ -2746,6 +3207,18 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  cacheable-lookup@5.0.4: {}
+
+  cacheable-request@7.0.4:
+    dependencies:
+      clone-response: 1.0.3
+      get-stream: 5.2.0
+      http-cache-semantics: 4.2.0
+      keyv: 4.5.4
+      lowercase-keys: 2.0.0
+      normalize-url: 6.1.0
+      responselike: 2.0.1
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -2765,6 +3238,14 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camelcase-keys@6.2.2:
+    dependencies:
+      camelcase: 5.3.1
+      map-obj: 4.3.0
+      quick-lru: 4.0.1
+
+  camelcase@5.3.1: {}
+
   caniuse-lite@1.0.30001737: {}
 
   chalk@4.1.2:
@@ -2777,6 +3258,10 @@ snapshots:
   chownr@3.0.0: {}
 
   client-only@0.0.1: {}
+
+  clone-response@1.0.3:
+    dependencies:
+      mimic-response: 1.0.1
 
   cmd-shim@7.0.0: {}
 
@@ -2797,6 +3282,10 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
     optional: true
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   concat-map@0.0.1: {}
 
@@ -2842,7 +3331,20 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decamelize-keys@1.1.1:
+    dependencies:
+      decamelize: 1.2.0
+      map-obj: 1.0.1
+
+  decamelize@1.2.0: {}
+
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+
   deep-is@0.1.4: {}
+
+  defer-to-connect@2.0.1: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -2855,6 +3357,8 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delayed-stream@1.0.0: {}
 
   detect-libc@2.0.4: {}
 
@@ -2872,10 +3376,18 @@ snapshots:
 
   emoji-regex@9.2.2: {}
 
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
   enhanced-resolve@5.18.3:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.3
+
+  error-ex@1.3.2:
+    dependencies:
+      is-arrayish: 0.2.1
 
   es-abstract@1.24.0:
     dependencies:
@@ -3177,6 +3689,10 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@3.1.2: {}
+
+  events@3.3.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
@@ -3220,6 +3736,11 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -3235,6 +3756,14 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  form-data@3.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -3252,6 +3781,8 @@ snapshots:
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
+
+  fuzzy@0.1.3: {}
 
   geojson-vt@4.0.2: {}
 
@@ -3272,6 +3803,10 @@ snapshots:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
+
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.3
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -3302,11 +3837,27 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  got@11.8.6:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      '@szmarczak/http-timer': 4.0.6
+      '@types/cacheable-request': 6.0.3
+      '@types/responselike': 1.0.3
+      cacheable-lookup: 5.0.4
+      cacheable-request: 7.0.4
+      decompress-response: 6.0.0
+      http2-wrapper: 1.0.3
+      lowercase-keys: 2.0.0
+      p-cancelable: 2.1.1
+      responselike: 2.0.1
+
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
 
   grid-index@1.1.0: {}
+
+  hard-rejection@2.1.0: {}
 
   has-bigints@1.1.0: {}
 
@@ -3330,6 +3881,19 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hosted-git-info@2.8.9: {}
+
+  hosted-git-info@4.1.0:
+    dependencies:
+      lru-cache: 6.0.0
+
+  http-cache-semantics@4.2.0: {}
+
+  http2-wrapper@1.0.3:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -3348,6 +3912,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0: {}
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -3359,6 +3925,8 @@ snapshots:
       call-bind: 1.0.8
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+
+  is-arrayish@0.2.1: {}
 
   is-arrayish@0.3.2:
     optional: true
@@ -3429,6 +3997,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-plain-obj@1.1.0: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -3491,6 +4061,8 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-parse-even-better-errors@2.3.1: {}
+
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
@@ -3511,6 +4083,8 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  kind-of@6.0.3: {}
 
   language-subtag-registry@0.3.23: {}
 
@@ -3568,15 +4142,29 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.30.1
       lightningcss-win32-x64-msvc: 1.30.1
 
+  lines-and-columns@1.2.4: {}
+
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash.debounce@4.0.8: {}
 
   lodash.merge@4.6.2: {}
 
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  lowercase-keys@2.0.0: {}
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
 
   lucide-react@0.542.0(react@19.1.0):
     dependencies:
@@ -3585,6 +4173,10 @@ snapshots:
   magic-string@0.30.18:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  map-obj@1.0.1: {}
+
+  map-obj@4.3.0: {}
 
   mapbox-gl@3.14.0:
     dependencies:
@@ -3624,12 +4216,39 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  meow@9.0.0:
+    dependencies:
+      '@types/minimist': 1.2.5
+      camelcase-keys: 6.2.2
+      decamelize: 1.2.0
+      decamelize-keys: 1.1.1
+      hard-rejection: 2.1.0
+      minimist-options: 4.1.0
+      normalize-package-data: 3.0.3
+      read-pkg-up: 7.0.1
+      redent: 3.0.0
+      trim-newlines: 3.0.1
+      type-fest: 0.18.1
+      yargs-parser: 20.2.9
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mimic-response@1.0.1: {}
+
+  mimic-response@3.1.0: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -3638,6 +4257,12 @@ snapshots:
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
+
+  minimist-options@4.1.0:
+    dependencies:
+      arrify: 1.0.1
+      is-plain-obj: 1.1.0
+      kind-of: 6.0.3
 
   minimist@1.2.8: {}
 
@@ -3690,6 +4315,22 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
+  normalize-package-data@2.5.0:
+    dependencies:
+      hosted-git-info: 2.8.9
+      resolve: 1.22.10
+      semver: 5.7.2
+      validate-npm-package-license: 3.0.4
+
+  normalize-package-data@3.0.3:
+    dependencies:
+      hosted-git-info: 4.1.0
+      is-core-module: 2.16.1
+      semver: 7.7.2
+      validate-npm-package-license: 3.0.4
+
+  normalize-url@6.1.0: {}
+
   npm-normalize-package-bin@4.0.0: {}
 
   object-assign@4.1.1: {}
@@ -3734,6 +4375,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -3749,17 +4394,36 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
+  p-cancelable@2.1.1: {}
+
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
+
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
 
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
 
+  p-try@2.2.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      error-ex: 1.3.2
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
 
   path-exists@4.0.0: {}
 
@@ -3805,9 +4469,18 @@ snapshots:
 
   protocol-buffers-schema@3.6.0: {}
 
+  pump@3.0.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  quick-lru@4.0.1: {}
+
+  quick-lru@5.1.1: {}
 
   quickselect@3.0.0: {}
 
@@ -3816,11 +4489,33 @@ snapshots:
       react: 19.1.0
       scheduler: 0.26.0
 
+  react-hook-form@7.62.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+
   react-is@16.13.1: {}
 
   react@19.1.0: {}
 
   read-cmd-shim@5.0.0: {}
+
+  read-pkg-up@7.0.1:
+    dependencies:
+      find-up: 4.1.0
+      read-pkg: 5.2.0
+      type-fest: 0.8.1
+
+  read-pkg@5.2.0:
+    dependencies:
+      '@types/normalize-package-data': 2.4.4
+      normalize-package-data: 2.5.0
+      parse-json: 5.2.0
+      type-fest: 0.6.0
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -3842,6 +4537,8 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  resolve-alpn@1.2.1: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -3861,6 +4558,10 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  responselike@2.0.1:
+    dependencies:
+      lowercase-keys: 2.0.0
 
   reusify@1.1.0: {}
 
@@ -3890,6 +4591,8 @@ snapshots:
       is-regex: 1.2.1
 
   scheduler@0.26.0: {}
+
+  semver@5.7.2: {}
 
   semver@6.3.1: {}
 
@@ -3992,6 +4695,20 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  spdx-correct@3.2.0:
+    dependencies:
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.22
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@3.0.1:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.22
+
+  spdx-license-ids@3.0.22: {}
+
   splaytree@0.1.4: {}
 
   stable-hash@0.0.5: {}
@@ -4053,12 +4770,23 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@3.1.1: {}
 
   styled-jsx@5.1.6(react@19.1.0):
     dependencies:
       client-only: 0.0.1
       react: 19.1.0
+
+  subtag@0.5.0: {}
+
+  suggestions@1.7.1:
+    dependencies:
+      fuzzy: 0.1.3
+      xtend: 4.0.2
 
   supabase@2.39.2:
     dependencies:
@@ -4107,6 +4835,8 @@ snapshots:
 
   tr46@0.0.3: {}
 
+  trim-newlines@3.0.1: {}
+
   ts-api-utils@2.1.0(typescript@5.9.2):
     dependencies:
       typescript: 5.9.2
@@ -4123,6 +4853,12 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@0.18.1: {}
+
+  type-fest@0.6.0: {}
+
+  type-fest@0.8.1: {}
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -4196,6 +4932,11 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  validate-npm-package-license@3.0.4:
+    dependencies:
+      spdx-correct: 3.2.0
+      spdx-expression-parse: 3.0.1
+
   web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
@@ -4252,6 +4993,8 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrappy@1.0.2: {}
+
   write-file-atomic@6.0.0:
     dependencies:
       imurmurhash: 0.1.4
@@ -4259,6 +5002,14 @@ snapshots:
 
   ws@8.18.3: {}
 
+  xtend@4.0.2: {}
+
+  yallist@4.0.0: {}
+
   yallist@5.0.0: {}
 
+  yargs-parser@20.2.9: {}
+
   yocto-queue@0.1.0: {}
+
+  zod@4.1.5: {}

--- a/src/app/(public)/map/page.tsx
+++ b/src/app/(public)/map/page.tsx
@@ -5,11 +5,11 @@ export default async function MapPage() {
   const supabase = await getServerSupabase();
   const { data, error } = await supabase
     .from("projects")
-    .select("id, title, lat, lng")
-    .eq("approval_status", "approved");
+    .select("id, name, lat, lng")
+    .eq("status", "approved");
   if (error) {
     return <Map markers={[]} />;
   }
-  const markers = (data ?? []).map(p => ({ id: p.id, title: p.title, lat: p.lat, lng: p.lng }));
+  const markers = (data ?? []).map(p => ({ id: p.id, title: p.name, lat: p.lat, lng: p.lng }));
   return <Map markers={markers} />;
 }

--- a/src/app/add/project/page.tsx
+++ b/src/app/add/project/page.tsx
@@ -8,7 +8,7 @@ const supabase = supabaseClient();
 export default function AddProjectPage() {
   const router = useRouter();
   const [me, setMe] = useState<string | null>(null);
-  const [title, setTitle] = useState("");
+  const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [leadOrgId, setLeadOrgId] = useState<string | null>(null);
   const [country, setCountry] = useState("");
@@ -27,25 +27,25 @@ export default function AddProjectPage() {
     e.preventDefault();
     if (!me) return;
     const { error } = await supabase.from("projects").insert({
-      title,
+      name,
       description,
       lead_org_id: leadOrgId,
       country,
       thematic_area: thematicArea,
       funding_needed: fundingNeeded,
-      review_status: "pending",
+      status: "pending",
       created_by: me,
     });
     if (error) { setStatusMsg(error.message); return; }
     setStatusMsg("Submitted for review. An admin will approve it.");
-    setTitle(""); setDescription(""); setLeadOrgId(null); setCountry(""); setThematicArea(""); setFundingNeeded(undefined);
+    setName(""); setDescription(""); setLeadOrgId(null); setCountry(""); setThematicArea(""); setFundingNeeded(undefined);
   }
 
   return (
     <div className="mx-auto max-w-3xl p-6">
       <h1 className="mb-4 text-2xl font-semibold">Add Project</h1>
       <form onSubmit={submit} className="space-y-3">
-        <input className="w-full rounded-xl border px-3 py-2" placeholder="Project title" value={title} onChange={e=>setTitle(e.target.value)} required />
+        <input className="w-full rounded-xl border px-3 py-2" placeholder="Project name" value={name} onChange={e=>setName(e.target.value)} required />
         <textarea className="w-full rounded-xl border px-3 py-2" placeholder="Description" value={description} onChange={e=>setDescription(e.target.value)} />
         <input className="w-full rounded-xl border px-3 py-2" placeholder="Lead organisation ID (optional)" value={leadOrgId ?? ""} onChange={e=>setLeadOrgId(e.target.value || null)} />
         <div className="flex gap-3">

--- a/src/app/admin/registrations/page.tsx
+++ b/src/app/admin/registrations/page.tsx
@@ -5,9 +5,10 @@ export default async function Page() {
   const { data: ok } = await supabase.rpc("is_admin");
   if (!ok) return new Response(null, { status: 404 }) as never;
 
+  // TODO: surface full metadata in /admin/projects/[id]
   const { data: projects, error } = await supabase
     .from("projects")
-    .select("id,title,description,lat,lng,approval_status,created_at,approved_at,approved_by,rejected_at,rejected_by,rejection_reason")
+    .select("id,name,description,lat,lng,status,created_at,approved_at,approved_by,rejected_at,rejected_by,rejection_reason")
     .order("created_at", { ascending: false });
   if (error) throw error;
 
@@ -18,25 +19,25 @@ export default async function Page() {
         <table className="min-w-full text-sm">
           <thead className="bg-gray-50">
             <tr>
-              {["Title","Status","Created","Approved By","Rejected By","Reason","Actions"].map(h => <th key={h} className="px-4 py-2 text-left">{h}</th>)}
+              {["Name","Status","Created","Approved By","Rejected By","Reason","Actions"].map(h => <th key={h} className="px-4 py-2 text-left">{h}</th>)}
             </tr>
           </thead>
           <tbody>
             {projects?.map(p => (
               <tr key={p.id} className="border-t">
-                <td className="px-4 py-2">{p.title}</td>
-                <td className="px-4 py-2 capitalize">{p.approval_status}</td>
+                <td className="px-4 py-2">{p.name}</td>
+                <td className="px-4 py-2 capitalize">{p.status}</td>
                 <td className="px-4 py-2">{new Date(p.created_at).toLocaleString()}</td>
                 <td className="px-4 py-2">{p.approved_by ?? ""}</td>
                 <td className="px-4 py-2">{p.rejected_by ?? ""}</td>
                 <td className="px-4 py-2">{p.rejection_reason ?? ""}</td>
                 <td className="px-4 py-2">
                   <form action={`/api/admin/projects/${p.id}/approve`} method="post" className="inline">
-                    <button className="rounded border px-3 py-1 hover:bg-gray-50" disabled={p.approval_status==="approved"}>Approve</button>
+                    <button className="rounded border px-3 py-1 hover:bg-gray-50" disabled={p.status==="approved"}>Approve</button>
                   </form>
                   <form action={`/api/admin/projects/${p.id}/reject`} method="post" className="ml-2 inline">
                     <input name="reason" placeholder="Reason" className="mr-2 rounded border px-2 py-1" />
-                    <button className="rounded border px-3 py-1 hover:bg-gray-50" disabled={p.approval_status==="rejected"}>Reject</button>
+                    <button className="rounded border px-3 py-1 hover:bg-gray-50" disabled={p.status==="rejected"}>Reject</button>
                   </form>
                 </td>
               </tr>

--- a/src/app/api/admin/projects/[id]/approve/route.ts
+++ b/src/app/api/admin/projects/[id]/approve/route.ts
@@ -13,7 +13,7 @@ export async function POST(
 
   const { data, error } = await supabase
     .from("projects")
-    .update({ approval_status: "approved" })
+    .update({ status: "approved" })
     .eq("id", id)
     .select()
     .single();

--- a/src/app/api/admin/projects/[id]/reject/route.ts
+++ b/src/app/api/admin/projects/[id]/reject/route.ts
@@ -15,7 +15,7 @@ export async function POST(
 
   const { data, error } = await supabase
     .from("projects")
-    .update({ approval_status: "rejected", rejection_reason: reason })
+    .update({ status: "rejected", rejection_reason: reason })
     .eq("id", id)
     .select()
     .single();

--- a/src/app/api/projects/[id]/approve/route.ts
+++ b/src/app/api/projects/[id]/approve/route.ts
@@ -11,7 +11,7 @@ export async function POST(req: Request) {
   if (!user) return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
   const { error } = await supabase
     .from("projects")
-    .update({ approval_status: "approved", approved_by: user.id, approved_at: new Date().toISOString() })
+    .update({ status: "approved", approved_by: user.id, approved_at: new Date().toISOString() })
     .eq("id", id);
   if (error) return NextResponse.json({ error: error.message }, { status: 400 });
   return NextResponse.json({ ok: true });

--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -4,14 +4,14 @@ import { getServerSupabase } from "@/lib/supabaseServer";
 export async function POST(req: NextRequest) {
   const supabase = await getServerSupabase();
   const body = await req.json();
-  const { title, description, lat, lng, org_name } = body ?? {};
+  const { name, description, lat, lng, org_name } = body ?? {};
   const { data: { user }, error: userErr } = await supabase.auth.getUser();
   if (userErr || !user) return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
   const { error } = await supabase.from("projects").insert({
-    title, description, lat, lng, org_name,
+    name, description, lat, lng, org_name,
     created_by: user.id,
-    approval_status: "pending"
+    status: "pending"
   });
   if (error) return NextResponse.json({ error: error.message }, { status: 400 });
-  return NextResponse.json({ ok: true, approval_status: "pending" });
+  return NextResponse.json({ ok: true, status: "pending" });
 }

--- a/src/app/api/projects/submit/route.ts
+++ b/src/app/api/projects/submit/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getServerSupabase } from "@/lib/supabaseServer";
+
+const linkSchema = z.object({ url: z.string().url(), label: z.string().optional() });
+const schema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  lead_org_id: z.string().uuid().optional(),
+  links: z.array(linkSchema).optional(),
+  partner_org_ids: z.array(z.string().uuid()).optional(),
+  sdg_ids: z.array(z.number()).optional(),
+  ifrc_ids: z.array(z.number()).optional(),
+  type_of_intervention: z.array(z.string()).optional(),
+  thematic_area: z.array(z.string()).optional(),
+  target_demographic: z.string().optional(),
+  lives_improved: z.number().optional(),
+  start_date: z.string().optional(),
+  end_date: z.string().optional(),
+  donations_received: z.number().optional(),
+  amount_needed: z.number().optional(),
+  currency: z.string().optional(),
+  location: z.object({ lat: z.number(), lng: z.number(), place_name: z.string() })
+}).refine(d => d.description || (d.links && d.links.length > 0), {
+  message: "Description or at least one link required",
+  path: ["description"],
+});
+
+export async function POST(req: Request) {
+  const supabase = await getServerSupabase();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+
+  const json = await req.json();
+  const parsed = schema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+  const data = parsed.data;
+  const { location, links = [], partner_org_ids = [], sdg_ids = [], ifrc_ids = [], type_of_intervention = [], thematic_area = [], ...rest } = data;
+
+  const { data: project, error } = await supabase
+    .from("projects")
+    .insert({
+      ...rest,
+      lat: location.lat,
+      lng: location.lng,
+      place_name: location.place_name,
+      type_of_intervention,
+      thematic_area,
+      status: "pending",
+      created_by: user.id,
+    })
+    .select("id,status")
+    .single();
+  if (error || !project) {
+    return NextResponse.json({ error: error?.message }, { status: 400 });
+  }
+  const projectId = project.id;
+
+  const linkRows = links.map(l => ({ project_id: projectId, url: l.url, label: l.label }));
+  if (linkRows.length) {
+    const { error: linkErr } = await supabase.from("project_links").insert(linkRows);
+    if (linkErr) {
+      await supabase.from("projects").delete().eq("id", projectId);
+      return NextResponse.json({ error: linkErr.message }, { status: 400 });
+    }
+  }
+  if (partner_org_ids.length) {
+    const { error: partnerErr } = await supabase.from("project_partners").insert(partner_org_ids.map(id => ({ project_id: projectId, organisation_id: id })));
+    if (partnerErr) {
+      await supabase.from("projects").delete().eq("id", projectId);
+      return NextResponse.json({ error: partnerErr.message }, { status: 400 });
+    }
+  }
+  if (sdg_ids.length) {
+    const { error: sdgErr } = await supabase.from("project_sdgs").insert(sdg_ids.map(id => ({ project_id: projectId, sdg_id: id })));
+    if (sdgErr) {
+      await supabase.from("projects").delete().eq("id", projectId);
+      return NextResponse.json({ error: sdgErr.message }, { status: 400 });
+    }
+  }
+  if (ifrc_ids.length) {
+    const { error: ifrcErr } = await supabase.from("project_ifrc_challenges").insert(ifrc_ids.map(id => ({ project_id: projectId, challenge_id: id })));
+    if (ifrcErr) {
+      await supabase.from("projects").delete().eq("id", projectId);
+      return NextResponse.json({ error: ifrcErr.message }, { status: 400 });
+    }
+  }
+
+  return NextResponse.json({ id: projectId, status: project.status });
+}

--- a/src/app/projects/new/page.tsx
+++ b/src/app/projects/new/page.tsx
@@ -1,0 +1,10 @@
+import ProjectForm from "@/components/projects/ProjectForm";
+
+export default function NewProjectPage() {
+  return (
+    <main className="mx-auto max-w-3xl p-6">
+      <h1 className="mb-4 text-2xl font-semibold">Add Project</h1>
+      <ProjectForm />
+    </main>
+  );
+}

--- a/src/components/MapGeocoder.tsx
+++ b/src/components/MapGeocoder.tsx
@@ -1,0 +1,25 @@
+"use client";
+import { useEffect, useRef } from "react";
+import mapboxgl from "mapbox-gl";
+import MapboxGeocoder from "@mapbox/mapbox-gl-geocoder";
+
+export default function MapGeocoder({ onSelect }: { onSelect: (v: { lat: number; lng: number; place_name: string }) => void }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    mapboxgl.accessToken = process.env.NEXT_PUBLIC_MAPBOX_TOKEN!;
+    const map = new mapboxgl.Map({ container: document.createElement("div"), style: "mapbox://styles/mapbox/streets-v11" });
+    const geocoder = new MapboxGeocoder({ accessToken: mapboxgl.accessToken, mapboxgl });
+    geocoder.addTo(containerRef.current!);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    geocoder.on("result", (e: any) => {
+      const [lng, lat] = e.result.center;
+      onSelect({ lat, lng, place_name: e.result.place_name });
+    });
+    return () => {
+      geocoder.clear();
+      geocoder.off("result", () => {});
+      map.remove();
+    };
+  }, [onSelect]);
+  return <div ref={containerRef} className="w-full" />;
+}

--- a/src/components/projects/ProjectForm.tsx
+++ b/src/components/projects/ProjectForm.tsx
@@ -1,0 +1,142 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useForm, useFieldArray } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { supabase } from "@/lib/supabase";
+import MultiSelect, { Option } from "@/components/ui/MultiSelect";
+import MapGeocoder from "@/components/MapGeocoder";
+
+const linkSchema = z.object({ url: z.string().url(), label: z.string().optional() });
+const formSchema = z.object({
+  name: z.string().min(1, "Name required"),
+  description: z.string().optional(),
+  lead_org_id: z.string().uuid().optional(),
+  links: z.array(linkSchema).default([]),
+  partner_org_ids: z.array(z.string().uuid()).default([]),
+  sdg_ids: z.array(z.number()).default([]),
+  ifrc_ids: z.array(z.number()).default([]),
+  type_of_intervention: z.array(z.string()).default([]),
+  thematic_area: z.array(z.string()).default([]),
+  target_demographic: z.string().optional(),
+  lives_improved: z.number().optional(),
+  start_date: z.string().optional(),
+  end_date: z.string().optional(),
+  donations_received: z.number().optional(),
+  amount_needed: z.number().optional(),
+  currency: z.string().optional(),
+  location: z.object({ lat: z.number(), lng: z.number(), place_name: z.string() }),
+}).refine(d => d.description || d.links.length > 0, {
+  message: "Description or at least one link required",
+  path: ["description"],
+});
+
+type FormValues = z.infer<typeof formSchema>;
+
+export default function ProjectForm() {
+  const router = useRouter();
+  const [orgOptions, setOrgOptions] = useState<Option[]>([]);
+  const [sdgOptions, setSdgOptions] = useState<Option[]>([]);
+  const [ifrcOptions, setIfrcOptions] = useState<Option[]>([]);
+  const [files, setFiles] = useState<FileList | null>(null);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const form = useForm<FormValues>({ resolver: zodResolver(formSchema) as any, defaultValues: { links: [], partner_org_ids: [], sdg_ids: [], ifrc_ids: [], type_of_intervention: [], thematic_area: [], location: { lat: 0, lng: 0, place_name: "" } } as any });
+  const { register, control, handleSubmit, setValue, watch, formState: { errors } } = form;
+  const { fields, append, remove } = useFieldArray({ control, name: "links" });
+
+  useEffect(() => {
+    supabase.from("organisations").select("id,name").then(({ data }) => {
+      setOrgOptions((data ?? []).map(o => ({ value: o.id, label: o.name })));
+    });
+    supabase.from("sdgs").select("id,name").then(({ data }) => {
+      setSdgOptions((data ?? []).map(o => ({ value: String(o.id), label: o.name })));
+    });
+    supabase.from("ifrc_challenges").select("id,name").then(({ data }) => {
+      setIfrcOptions((data ?? []).map(o => ({ value: String(o.id), label: o.name })));
+    });
+  }, []);
+
+  async function onSubmit(values: FormValues) {
+    const res = await fetch("/api/projects/submit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(values),
+    });
+    if (!res.ok) {
+      console.error(await res.text());
+      return;
+    }
+    const { id } = await res.json();
+    if (files && files.length) {
+      for (const file of Array.from(files)) {
+        const ext = file.name.split(".").pop();
+        const path = `${id}/${crypto.randomUUID()}.${ext}`;
+        const { error: upErr } = await supabase.storage.from("project-media").upload(path, file);
+        if (!upErr) {
+          await supabase.from("project_media").insert({ project_id: id, path, mime_type: file.type, caption: file.name });
+        }
+      }
+    }
+    router.push("/projects");
+  }
+
+  const location = watch("location");
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium">Name</label>
+        <input className="mt-1 w-full rounded border px-3 py-2" {...register("name")} />
+        {errors.name && <p className="text-sm text-red-500">{errors.name.message}</p>}
+      </div>
+      <div>
+        <label className="block text-sm font-medium">Description</label>
+        <textarea className="mt-1 w-full rounded border px-3 py-2" {...register("description")} />
+        {errors.description && <p className="text-sm text-red-500">{errors.description.message}</p>}
+      </div>
+      <div>
+        <label className="block text-sm font-medium">Links</label>
+        {fields.map((f, i) => (
+          <div key={f.id} className="mb-2 flex gap-2">
+            <input className="w-1/2 rounded border px-2 py-1" placeholder="URL" {...register(`links.${i}.url` as const)} />
+            <input className="w-1/2 rounded border px-2 py-1" placeholder="Label" {...register(`links.${i}.label` as const)} />
+            <button type="button" onClick={() => remove(i)} className="rounded border px-2">x</button>
+          </div>
+        ))}
+        <button type="button" onClick={() => append({ url: "", label: "" })} className="rounded border px-3 py-1">Add Link</button>
+      </div>
+      <div>
+        <label className="block text-sm font-medium">Lead Organisation</label>
+        <select className="mt-1 w-full rounded border px-3 py-2" {...register("lead_org_id")}> 
+          <option value="">Select...</option>
+          {orgOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+        </select>
+      </div>
+      <div>
+        <label className="block text-sm font-medium">Partners</label>
+        <MultiSelect options={orgOptions} value={watch("partner_org_ids")} onChange={v => setValue("partner_org_ids", v)} />
+      </div>
+      <div>
+        <label className="block text-sm font-medium">SDGs</label>
+        <MultiSelect options={sdgOptions} value={watch("sdg_ids").map(String)} onChange={v => setValue("sdg_ids", v.map(Number))} />
+      </div>
+      <div>
+        <label className="block text-sm font-medium">IFRC Challenges</label>
+        <MultiSelect options={ifrcOptions} value={watch("ifrc_ids").map(String)} onChange={v => setValue("ifrc_ids", v.map(Number))} />
+      </div>
+      <div>
+        <label className="block text-sm font-medium">Location</label>
+        <MapGeocoder onSelect={loc => setValue("location", loc)} />
+        {location.place_name && <p className="mt-1 text-sm">{location.place_name}</p>}
+        {errors.location && <p className="text-sm text-red-500">Location required</p>}
+      </div>
+      <div>
+        <label className="block text-sm font-medium">Media</label>
+        <input type="file" multiple onChange={e => setFiles(e.target.files)} />
+      </div>
+      <button type="submit" className="rounded border px-4 py-2">Submit</button>
+    </form>
+  );
+}

--- a/src/components/ui/MultiSelect.tsx
+++ b/src/components/ui/MultiSelect.tsx
@@ -1,0 +1,21 @@
+"use client";
+import React from "react";
+
+export type Option = { value: string; label: string };
+
+export default function MultiSelect({ options, value, onChange }: { options: Option[]; value: string[]; onChange: (v: string[]) => void }) {
+  function toggle(v: string) {
+    if (value.includes(v)) onChange(value.filter(x => x !== v));
+    else onChange([...value, v]);
+  }
+  return (
+    <div className="flex flex-wrap gap-2">
+      {options.map(opt => (
+        <label key={opt.value} className="flex items-center gap-1 text-sm">
+          <input type="checkbox" checked={value.includes(opt.value)} onChange={() => toggle(opt.value)} />
+          <span>{opt.label}</span>
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/src/lib/rpc.ts
+++ b/src/lib/rpc.ts
@@ -1,0 +1,9 @@
+export async function rpc<T>(url: string, body: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json() as Promise<T>;
+}

--- a/src/types/mapbox-gl-geocoder.d.ts
+++ b/src/types/mapbox-gl-geocoder.d.ts
@@ -1,0 +1,1 @@
+declare module "@mapbox/mapbox-gl-geocoder";

--- a/supabase/migrations/20250905120000_projects_extended.sql
+++ b/supabase/migrations/20250905120000_projects_extended.sql
@@ -1,0 +1,377 @@
+-- Ensure organisations table exists
+create table if not exists public.organisations (
+  id uuid primary key default gen_random_uuid(),
+  name text not null
+);
+
+-- Projects table and columns
+create table if not exists public.projects (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  description text,
+  lead_org_id uuid references public.organisations(id),
+  lat double precision,
+  lng double precision,
+  place_name text,
+  type_of_intervention text[],
+  target_demographic text,
+  lives_improved integer,
+  start_date date,
+  end_date date,
+  thematic_area text[],
+  donations_received numeric,
+  amount_needed numeric,
+  currency text default 'USD',
+  status text default 'pending' check (status in ('pending','approved','rejected')),
+  created_by uuid default auth.uid(),
+  created_at timestamptz default now()
+);
+
+-- Rename / add columns for existing projects table
+DO $$
+BEGIN
+  -- rename title -> name
+  IF exists (select 1 from information_schema.columns where table_name='projects' and column_name='title')
+     AND not exists (select 1 from information_schema.columns where table_name='projects' and column_name='name') THEN
+    ALTER TABLE public.projects RENAME COLUMN title TO name;
+  END IF;
+  -- rename old status to lifecycle_status if approval_status also exists
+  IF exists (select 1 from information_schema.columns where table_name='projects' and column_name='status')
+     AND exists (select 1 from information_schema.columns where table_name='projects' and column_name='approval_status') THEN
+    ALTER TABLE public.projects RENAME COLUMN status TO lifecycle_status;
+  END IF;
+  -- rename approval_status -> status
+  IF exists (select 1 from information_schema.columns where table_name='projects' and column_name='approval_status') THEN
+    ALTER TABLE public.projects RENAME COLUMN approval_status TO status;
+    ALTER TABLE public.projects ALTER COLUMN status TYPE text USING status::text;
+    ALTER TABLE public.projects ALTER COLUMN status SET DEFAULT 'pending';
+    ALTER TABLE public.projects ADD CONSTRAINT projects_status_check CHECK (status in ('pending','approved','rejected'));
+  END IF;
+  -- rename funding_needed -> amount_needed
+  IF exists (select 1 from information_schema.columns where table_name='projects' and column_name='funding_needed')
+     AND not exists (select 1 from information_schema.columns where table_name='projects' and column_name='amount_needed') THEN
+    ALTER TABLE public.projects RENAME COLUMN funding_needed TO amount_needed;
+  END IF;
+  -- add place_name
+  IF not exists (select 1 from information_schema.columns where table_name='projects' and column_name='place_name') THEN
+    ALTER TABLE public.projects ADD COLUMN place_name text;
+  END IF;
+  -- add type_of_intervention
+  IF not exists (select 1 from information_schema.columns where table_name='projects' and column_name='type_of_intervention') THEN
+    ALTER TABLE public.projects ADD COLUMN type_of_intervention text[];
+  END IF;
+  -- add target_demographic
+  IF not exists (select 1 from information_schema.columns where table_name='projects' and column_name='target_demographic') THEN
+    ALTER TABLE public.projects ADD COLUMN target_demographic text;
+  END IF;
+  -- ensure thematic_area is text[]
+  IF exists (select 1 from information_schema.columns where table_name='projects' and column_name='thematic_area') THEN
+    IF (select data_type from information_schema.columns where table_name='projects' and column_name='thematic_area') <> 'ARRAY' THEN
+      ALTER TABLE public.projects ALTER COLUMN thematic_area TYPE text[] USING ARRAY[thematic_area];
+    END IF;
+  ELSE
+    ALTER TABLE public.projects ADD COLUMN thematic_area text[];
+  END IF;
+  -- donations_received
+  IF not exists (select 1 from information_schema.columns where table_name='projects' and column_name='donations_received') THEN
+    ALTER TABLE public.projects ADD COLUMN donations_received numeric;
+  END IF;
+  -- amount_needed
+  IF not exists (select 1 from information_schema.columns where table_name='projects' and column_name='amount_needed') THEN
+    ALTER TABLE public.projects ADD COLUMN amount_needed numeric;
+  END IF;
+  -- currency
+  IF not exists (select 1 from information_schema.columns where table_name='projects' and column_name='currency') THEN
+    ALTER TABLE public.projects ADD COLUMN currency text DEFAULT 'USD';
+  END IF;
+  -- created_by default
+  IF exists (select 1 from information_schema.columns where table_name='projects' and column_name='created_by') THEN
+    ALTER TABLE public.projects ALTER COLUMN created_by SET DEFAULT auth.uid();
+  ELSE
+    ALTER TABLE public.projects ADD COLUMN created_by uuid DEFAULT auth.uid();
+  END IF;
+  -- created_at
+  IF not exists (select 1 from information_schema.columns where table_name='projects' and column_name='created_at') THEN
+    ALTER TABLE public.projects ADD COLUMN created_at timestamptz DEFAULT now();
+  END IF;
+END$$;
+
+-- New tables
+create table if not exists public.project_links (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid references public.projects(id) on delete cascade,
+  url text not null,
+  label text,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.project_partners (
+  project_id uuid references public.projects(id) on delete cascade,
+  organisation_id uuid references public.organisations(id) on delete cascade,
+  primary key (project_id, organisation_id)
+);
+
+create table if not exists public.sdgs (
+  id int primary key,
+  name text not null
+);
+insert into public.sdgs (id, name) values
+  (1, 'No Poverty'),
+  (2, 'Zero Hunger'),
+  (3, 'Good Health and Well-being'),
+  (4, 'Quality Education'),
+  (5, 'Gender Equality'),
+  (6, 'Clean Water and Sanitation'),
+  (7, 'Affordable and Clean Energy'),
+  (8, 'Decent Work and Economic Growth'),
+  (9, 'Industry, Innovation and Infrastructure'),
+  (10, 'Reduced Inequalities'),
+  (11, 'Sustainable Cities and Communities'),
+  (12, 'Responsible Consumption and Production'),
+  (13, 'Climate Action'),
+  (14, 'Life Below Water'),
+  (15, 'Life on Land'),
+  (16, 'Peace, Justice and Strong Institutions'),
+  (17, 'Partnerships for the Goals')
+  on conflict do nothing;
+
+create table if not exists public.ifrc_challenges (
+  id serial primary key,
+  code text unique,
+  name text not null
+);
+insert into public.ifrc_challenges (code, name) values
+  ('climate_crises', 'Climate and Crises'),
+  ('health', 'Health'),
+  ('migration_identity', 'Migration and Identity'),
+  ('values_power_inclusion', 'Values, Power and Inclusion'),
+  ('trust_digital', 'Trust and Digital')
+  on conflict (code) do nothing;
+
+create table if not exists public.project_sdgs (
+  project_id uuid references public.projects(id) on delete cascade,
+  sdg_id int references public.sdgs(id) on delete cascade,
+  primary key (project_id, sdg_id)
+);
+
+create table if not exists public.project_ifrc_challenges (
+  project_id uuid references public.projects(id) on delete cascade,
+  challenge_id int references public.ifrc_challenges(id) on delete cascade,
+  primary key (project_id, challenge_id)
+);
+
+create table if not exists public.project_media (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid references public.projects(id) on delete cascade,
+  path text not null,
+  mime_type text,
+  caption text,
+  created_by uuid default auth.uid(),
+  created_at timestamptz default now()
+);
+
+create table if not exists public.project_posts (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid references public.projects(id) on delete cascade,
+  title text,
+  content text,
+  created_by uuid default auth.uid(),
+  created_at timestamptz default now()
+);
+
+-- Enable RLS
+alter table public.project_links enable row level security;
+alter table public.project_partners enable row level security;
+alter table public.sdgs enable row level security;
+alter table public.ifrc_challenges enable row level security;
+alter table public.project_sdgs enable row level security;
+alter table public.project_ifrc_challenges enable row level security;
+alter table public.project_media enable row level security;
+alter table public.project_posts enable row level security;
+alter table public.projects enable row level security;
+
+-- RLS for projects
+-- drop existing policies
+DROP POLICY IF EXISTS "projects_public_read_approved" ON public.projects;
+DROP POLICY IF EXISTS "projects_read_admin_all" ON public.projects;
+DROP POLICY IF EXISTS "projects_read_own_pending" ON public.projects;
+DROP POLICY IF EXISTS "projects_update_admin_moderation" ON public.projects;
+DROP POLICY IF EXISTS "projects_update_own_pending" ON public.projects;
+DROP POLICY IF EXISTS "projects_insert_auth" ON public.projects;
+
+CREATE POLICY "projects_select" ON public.projects
+  FOR SELECT USING (status = 'approved' OR auth.uid() = created_by OR public.is_admin());
+
+CREATE POLICY "projects_insert" ON public.projects
+  FOR INSERT TO authenticated WITH CHECK (auth.uid() = created_by AND status = 'pending');
+
+CREATE POLICY "projects_update_owner" ON public.projects
+  FOR UPDATE USING (auth.uid() = created_by AND status = 'pending') WITH CHECK (auth.uid() = created_by);
+
+CREATE POLICY "projects_update_admin" ON public.projects
+  FOR UPDATE USING (public.is_admin()) WITH CHECK (true);
+
+CREATE POLICY "projects_delete_owner" ON public.projects
+  FOR DELETE USING (auth.uid() = created_by AND status = 'pending');
+
+CREATE POLICY "projects_delete_admin" ON public.projects
+  FOR DELETE USING (public.is_admin());
+
+-- Helper expression for child table policies
+-- project_links policies
+DROP POLICY IF EXISTS "project_links_select" ON public.project_links;
+CREATE POLICY "project_links_select" ON public.project_links
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.projects p
+      WHERE p.id = project_links.project_id
+        AND (p.status = 'approved' OR auth.uid() = p.created_by OR public.is_admin())
+    )
+  );
+DROP POLICY IF EXISTS "project_links_owner_mod" ON public.project_links;
+CREATE POLICY "project_links_owner_mod" ON public.project_links
+  FOR INSERT TO authenticated WITH CHECK (
+    EXISTS (SELECT 1 FROM public.projects p WHERE p.id = project_links.project_id AND p.created_by = auth.uid() AND p.status = 'pending')
+  );
+CREATE POLICY "project_links_owner_update" ON public.project_links
+  FOR UPDATE USING (
+    EXISTS (SELECT 1 FROM public.projects p WHERE p.id = project_links.project_id AND p.created_by = auth.uid() AND p.status = 'pending')
+  ) WITH CHECK (
+    EXISTS (SELECT 1 FROM public.projects p WHERE p.id = project_links.project_id AND p.created_by = auth.uid() AND p.status = 'pending')
+  );
+CREATE POLICY "project_links_owner_delete" ON public.project_links
+  FOR DELETE USING (
+    EXISTS (SELECT 1 FROM public.projects p WHERE p.id = project_links.project_id AND p.created_by = auth.uid() AND p.status = 'pending')
+  );
+CREATE POLICY "project_links_admin_all" ON public.project_links
+  FOR ALL USING (public.is_admin()) WITH CHECK (true);
+
+-- project_partners policies
+DROP POLICY IF EXISTS "project_partners_select" ON public.project_partners;
+CREATE POLICY "project_partners_select" ON public.project_partners
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.projects p
+      WHERE p.id = project_partners.project_id
+        AND (p.status = 'approved' OR auth.uid() = p.created_by OR public.is_admin())
+    )
+  );
+DROP POLICY IF EXISTS "project_partners_owner_mod" ON public.project_partners;
+CREATE POLICY "project_partners_owner_mod" ON public.project_partners
+  FOR INSERT TO authenticated WITH CHECK (
+    EXISTS (SELECT 1 FROM public.projects p WHERE p.id = project_partners.project_id AND p.created_by = auth.uid() AND p.status = 'pending')
+  );
+CREATE POLICY "project_partners_owner_update" ON public.project_partners
+  FOR UPDATE USING (
+    EXISTS (SELECT 1 FROM public.projects p WHERE p.id = project_partners.project_id AND p.created_by = auth.uid() AND p.status = 'pending')
+  ) WITH CHECK (
+    EXISTS (SELECT 1 FROM public.projects p WHERE p.id = project_partners.project_id AND p.created_by = auth.uid() AND p.status = 'pending')
+  );
+CREATE POLICY "project_partners_owner_delete" ON public.project_partners
+  FOR DELETE USING (
+    EXISTS (SELECT 1 FROM public.projects p WHERE p.id = project_partners.project_id AND p.created_by = auth.uid() AND p.status = 'pending')
+  );
+CREATE POLICY "project_partners_admin_all" ON public.project_partners
+  FOR ALL USING (public.is_admin()) WITH CHECK (true);
+
+-- project_sdgs policies
+DROP POLICY IF EXISTS "project_sdgs_select" ON public.project_sdgs;
+CREATE POLICY "project_sdgs_select" ON public.project_sdgs
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.projects p
+      WHERE p.id = project_sdgs.project_id
+        AND (p.status = 'approved' OR auth.uid() = p.created_by OR public.is_admin())
+    )
+  );
+DROP POLICY IF EXISTS "project_sdgs_owner_mod" ON public.project_sdgs;
+CREATE POLICY "project_sdgs_owner_mod" ON public.project_sdgs
+  FOR INSERT TO authenticated WITH CHECK (
+    EXISTS (SELECT 1 FROM public.projects p WHERE p.id = project_sdgs.project_id AND p.created_by = auth.uid() AND p.status = 'pending')
+  );
+CREATE POLICY "project_sdgs_owner_delete" ON public.project_sdgs
+  FOR DELETE USING (
+    EXISTS (SELECT 1 FROM public.projects p WHERE p.id = project_sdgs.project_id AND p.created_by = auth.uid() AND p.status = 'pending')
+  );
+CREATE POLICY "project_sdgs_admin_all" ON public.project_sdgs
+  FOR ALL USING (public.is_admin()) WITH CHECK (true);
+
+-- project_ifrc_challenges policies
+DROP POLICY IF EXISTS "project_ifrc_select" ON public.project_ifrc_challenges;
+CREATE POLICY "project_ifrc_select" ON public.project_ifrc_challenges
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.projects p
+      WHERE p.id = project_ifrc_challenges.project_id
+        AND (p.status = 'approved' OR auth.uid() = p.created_by OR public.is_admin())
+    )
+  );
+DROP POLICY IF EXISTS "project_ifrc_owner_mod" ON public.project_ifrc_challenges;
+CREATE POLICY "project_ifrc_owner_mod" ON public.project_ifrc_challenges
+  FOR INSERT TO authenticated WITH CHECK (
+    EXISTS (SELECT 1 FROM public.projects p WHERE p.id = project_ifrc_challenges.project_id AND p.created_by = auth.uid() AND p.status = 'pending')
+  );
+CREATE POLICY "project_ifrc_owner_delete" ON public.project_ifrc_challenges
+  FOR DELETE USING (
+    EXISTS (SELECT 1 FROM public.projects p WHERE p.id = project_ifrc_challenges.project_id AND p.created_by = auth.uid() AND p.status = 'pending')
+  );
+CREATE POLICY "project_ifrc_admin_all" ON public.project_ifrc_challenges
+  FOR ALL USING (public.is_admin()) WITH CHECK (true);
+
+-- project_media policies
+DROP POLICY IF EXISTS "project_media_select" ON public.project_media;
+CREATE POLICY "project_media_select" ON public.project_media
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.projects p
+      WHERE p.id = project_media.project_id
+        AND (p.status = 'approved' OR auth.uid() = p.created_by OR public.is_admin())
+    )
+  );
+DROP POLICY IF EXISTS "project_media_owner_mod" ON public.project_media;
+CREATE POLICY "project_media_owner_mod" ON public.project_media
+  FOR INSERT TO authenticated WITH CHECK (
+    EXISTS (SELECT 1 FROM public.projects p WHERE p.id = project_media.project_id AND p.created_by = auth.uid() AND p.status = 'pending')
+  );
+CREATE POLICY "project_media_owner_update" ON public.project_media
+  FOR UPDATE USING (
+    EXISTS (SELECT 1 FROM public.projects p WHERE p.id = project_media.project_id AND p.created_by = auth.uid() AND p.status = 'pending')
+  ) WITH CHECK (
+    EXISTS (SELECT 1 FROM public.projects p WHERE p.id = project_media.project_id AND p.created_by = auth.uid() AND p.status = 'pending')
+  );
+CREATE POLICY "project_media_owner_delete" ON public.project_media
+  FOR DELETE USING (
+    EXISTS (SELECT 1 FROM public.projects p WHERE p.id = project_media.project_id AND p.created_by = auth.uid() AND p.status = 'pending')
+  );
+CREATE POLICY "project_media_admin_all" ON public.project_media
+  FOR ALL USING (public.is_admin()) WITH CHECK (true);
+
+-- project_posts policies
+DROP POLICY IF EXISTS "project_posts_select" ON public.project_posts;
+CREATE POLICY "project_posts_select" ON public.project_posts
+  FOR SELECT USING (
+    EXISTS (
+      SELECT 1 FROM public.projects p
+      WHERE p.id = project_posts.project_id
+        AND (p.status = 'approved' OR auth.uid() = p.created_by OR public.is_admin())
+    )
+  );
+DROP POLICY IF EXISTS "project_posts_owner_mod" ON public.project_posts;
+CREATE POLICY "project_posts_owner_mod" ON public.project_posts
+  FOR INSERT TO authenticated WITH CHECK (
+    EXISTS (SELECT 1 FROM public.projects p WHERE p.id = project_posts.project_id AND p.created_by = auth.uid() AND p.status = 'pending')
+  );
+CREATE POLICY "project_posts_owner_update" ON public.project_posts
+  FOR UPDATE USING (
+    EXISTS (SELECT 1 FROM public.projects p WHERE p.id = project_posts.project_id AND p.created_by = auth.uid() AND p.status = 'pending')
+  ) WITH CHECK (
+    EXISTS (SELECT 1 FROM public.projects p WHERE p.id = project_posts.project_id AND p.created_by = auth.uid() AND p.status = 'pending')
+  );
+CREATE POLICY "project_posts_owner_delete" ON public.project_posts
+  FOR DELETE USING (
+    EXISTS (SELECT 1 FROM public.projects p WHERE p.id = project_posts.project_id AND p.created_by = auth.uid() AND p.status = 'pending')
+  );
+CREATE POLICY "project_posts_admin_all" ON public.project_posts
+  FOR ALL USING (public.is_admin()) WITH CHECK (true);
+
+-- End of migration


### PR DESCRIPTION
## Summary
- expand database schema for projects, organisations, links, partners, SDGs, IFRC challenges, media, and posts with RLS
- add `/api/projects/submit` endpoint inserting projects and related records
- build ProjectForm with Mapbox geocoder, multi-selects, and storage uploads
- refresh admin listings and map queries for new `status` and `name` fields

## Testing
- `pnpm lint`
- `pnpm build` with dummy env vars
- `npx supabase gen types typescript --project-id "$SUPABASE_PROJECT_ID" --schema public` *(fails: Access token not provided)*

------
https://chatgpt.com/codex/tasks/task_e_68b83c7bbc188326bb64e80edca753e3