### PR TITLE
fix(migrations): normalize $$ blocks across migrations

### DIFF
--- a/supabase/migrations/20250827000001_prep_profiles.sql
+++ b/supabase/migrations/20250827000001_prep_profiles.sql
@@ -1,30 +1,30 @@
 -- Add profiles.role if missing
-do 354
+do $$
 begin
   if not exists (
     select 1 from information_schema.columns
-    where table_schema = public and table_name = profiles and column_name = role
+    where table_schema = 'public' and table_name = 'profiles' and column_name = 'role'
   ) then
     alter table public.profiles add column role text;
   end if;
-end 354;
+end $$;
 
 -- Create is_admin(uid) if missing
-do 354
+do $$
 begin
   if not exists (
     select 1
     from pg_proc p join pg_namespace n on n.oid = p.pronamespace
-    where n.nspname = public and p.proname = is_admin
+    where n.nspname = 'public' and p.proname = 'is_admin'
   ) then
     create function public.is_admin(uid uuid default auth.uid())
     returns boolean
     language sql stable
-    as 1994
+    as $$
       select exists (
         select 1 from public.profiles pr
-        where pr.id = uid and pr.role in (admin,superadmin)
+        where pr.id = uid and pr.role in ('admin','superadmin')
       );
-    1994;
+    $$;
   end if;
-end 354;
+end $$;

--- a/supabase/migrations/20250828_roles_projects.sql
+++ b/supabase/migrations/20250828_roles_projects.sql
@@ -1,40 +1,40 @@
 -- Ensure profiles.role exists
-do 354
+do $$
 begin
   if not exists (
     select 1 from information_schema.columns
-    where table_schema = public and table_name = profiles and column_name = role
+    where table_schema = 'public' and table_name = 'profiles' and column_name = 'role'
   ) then
     alter table public.profiles add column role text;
   end if;
-end 354;
+end $$;
 
 -- Ensure is_admin(uid) exists
-do 354
+do $$
 begin
   if not exists (
     select 1
     from pg_proc p join pg_namespace n on n.oid = p.pronamespace
-    where n.nspname = public and p.proname = is_admin
+    where n.nspname = 'public' and p.proname = 'is_admin'
   ) then
     create function public.is_admin(uid uuid default auth.uid())
     returns boolean
     language sql stable
-    as 24323
+    as $$
       select exists (
         select 1 from public.profiles pr
-        where pr.id = uid and pr.role in (admin,superadmin)
+        where pr.id = uid and pr.role in ('admin','superadmin')
       );
-    24323;
+    $$;
   end if;
-end 354;
+end $$;
 
 -- Recreate policy using is_admin(); drop only if it exists
-do 354
+do $$
 begin
   if exists (
     select 1 from pg_policies
-    where schemaname = public and tablename = profiles and policyname = profiles_public_read_admin_only
+    where schemaname = 'public' and tablename = 'profiles' and policyname = 'profiles_public_read_admin_only'
   ) then
     drop policy "profiles_public_read_admin_only" on public.profiles;
   end if;
@@ -43,17 +43,17 @@ begin
   on public.profiles
   for select
   using (public.is_admin(auth.uid()));
-end 354;
+end $$;
 -- Ensure profiles.role exists
 do $$
 begin
   if not exists (
     select 1 from information_schema.columns
-    where table_schema = public and table_name = profiles and column_name = role
+    where table_schema = 'public' and table_name = 'profiles' and column_name = 'role'
   ) then
     alter table public.profiles add column role text;
   end if;
-end 354;
+end $$;
 
 -- Ensure is_admin(uid) exists
 do $$
@@ -61,26 +61,26 @@ begin
   if not exists (
     select 1
     from pg_proc p join pg_namespace n on n.oid = p.pronamespace
-    where n.nspname = public and p.proname = is_admin
+    where n.nspname = 'public' and p.proname = 'is_admin'
   ) then
     create function public.is_admin(uid uuid default auth.uid())
     returns boolean
     language sql stable
-    as 22942
+    as $$
       select exists (
         select 1 from public.profiles pr
-        where pr.id = uid and pr.role in (admin,superadmin)
+        where pr.id = uid and pr.role in ('admin','superadmin')
       );
-    22942;
+    $$;
   end if;
-end 354;
+end $$;
 
 -- Recreate policy using is_admin(); drop only if it exists
 do $$
 begin
   if exists (
     select 1 from pg_policies
-    where schemaname = public and tablename = profiles and policyname = profiles_public_read_admin_only
+    where schemaname = 'public' and tablename = 'profiles' and policyname = 'profiles_public_read_admin_only'
   ) then
     drop policy "profiles_public_read_admin_only" on public.profiles;
   end if;
@@ -89,7 +89,7 @@ begin
   on public.profiles
   for select
   using (public.is_admin(auth.uid()));
-end 354;
+end $$;
 -- enums
 create type user_role as enum ('admin','member');
 create type project_status as enum ('pending','approved','rejected');


### PR DESCRIPTION
## Summary
- replace corrupted anonymous block delimiters in `prep_profiles` migration with `$$` and restore string literals so the guards run again
- normalize duplicated guard blocks in `roles_projects` migration to use `$$` delimiters and valid string comparisons

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68caca72f94883269bd0088fc747bcb1