### PR TITLE
Fix project creation links to new project route

### DIFF
--- a/src/app/projects/new/confirmation/page.tsx
+++ b/src/app/projects/new/confirmation/page.tsx
@@ -15,7 +15,7 @@ export default function ProjectConfirmationPage() {
         >
           Browse projects
         </Link>
-        <Link href="/add/project" className="text-sm font-medium text-emerald-700 hover:text-emerald-800">
+        <Link href="/projects/new" className="text-sm font-medium text-emerald-700 hover:text-emerald-800">
           Submit another project
         </Link>
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -112,7 +112,7 @@ export default function Header() {
 
   const addButton = (
     <Link
-      href="/add/project"
+      href="/projects/new"
       className="grid h-9 w-9 place-items-center rounded-full border"
       aria-label="Add Project"
     >

--- a/src/components/add/AddAction.tsx
+++ b/src/components/add/AddAction.tsx
@@ -4,13 +4,13 @@ import { useMemo } from "react";
 
 /**
  * Circular + button that on hover slides left to reveal text.
- * Org → "Add Project" → /add/project
+ * Org → "Add Project" → /projects/new
  * Individual → "Add Watchdog Case" → /add/watchdog
  */
 export default function AddAction({ accountKind }: { accountKind: "individual" | "organisation" }) {
   const conf = useMemo(() => {
     return accountKind === "organisation"
-      ? { href: "/add/project", label: "Add Project" }
+      ? { href: "/projects/new", label: "Add Project" }
       : { href: "/add/watchdog", label: "Add Watchdog Case" };
   }, [accountKind]);
 


### PR DESCRIPTION
## Summary
- update header add-project shortcut to target the new `/projects/new` route
- adjust the AddAction component to send organisation users to `/projects/new`
- refresh the confirmation page link so repeat submissions use the new project form

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db911de5d48326bfcab754adcfc3aa