### PR TITLE
Fix Mapbox geocoder mounting, align IFRC seeds, and refine project form inputs

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@
 import "./globals.css";
 import "mapbox-gl/dist/mapbox-gl.css";
 import "@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css";
+import "react-day-picker/dist/style.css";
 
 import type { Metadata } from "next";
 import { ReactNode } from "react";

--- a/supabase/migrations/20251001120000_fix_ifrc_challenges.sql
+++ b/supabase/migrations/20251001120000_fix_ifrc_challenges.sql
@@ -1,0 +1,25 @@
+-- Ensure table exists
+create table if not exists public.ifrc_challenges (
+  id serial primary key,
+  code text unique,
+  name text not null
+);
+
+-- Upsert the five canonical challenges
+insert into public.ifrc_challenges (code, name) values
+  ('climate_environmental_crisis', 'Climate and environmental crisis'),
+  ('evolving_crises_disasters', 'Evolving crisis and disasters'),
+  ('growing_gaps_health_wellbeing', 'Growing gaps in health and well-being'),
+  ('migration_identity', 'Migration and identity'),
+  ('values_power_inclusion', 'Values, power and inclusion')
+on conflict (code) do update set name = excluded.name;
+
+-- Remove any rows not in the whitelist (safe cleanup)
+delete from public.ifrc_challenges
+where code not in (
+  'climate_environmental_crisis',
+  'evolving_crises_disasters',
+  'growing_gaps_health_wellbeing',
+  'migration_identity',
+  'values_power_inclusion'
+);


### PR DESCRIPTION
## Summary
- guard the Mapbox geocoder so it only mounts once per instance and keeps the latest onSelect handler
- toggle the location picker in the project form behind an “Add/Change location” button
- import Day Picker CSS globally so date pickers render with the expected calendar popover styling
- add a migration that canonicalises the IFRC Global Challenge seed names
- keep the “Add tag” button label on one line while retaining the existing intervention and thematic badge logic
- replace the currency text input with a dropdown and swap the timeline calendar for DD/MM/YYYY selects to avoid the previous glitchy picker

## Testing
- pnpm lint
- pnpm build *(fails: requires Supabase project URL/API key during prerender)*

------
https://chatgpt.com/codex/tasks/task_e_68dc106e043083269e2eef5d6c0759da