### PR TITLE
Add admin interfaces for reviewing projects

### DIFF
--- a/src/app/admin/projects/[id]/page.tsx
+++ b/src/app/admin/projects/[id]/page.tsx
@@ -1,0 +1,144 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { getServerSupabase } from "@/lib/supabaseServer";
+import Map from "@/components/Map";
+
+export default async function AdminProjectDetail({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const supabase = await getServerSupabase();
+  const { id } = await params;
+  const { data: isAdmin } = await supabase.rpc("is_admin");
+  if (!isAdmin) return new Response(null, { status: 404 }) as never;
+
+  const { data: project, error } = await supabase
+    .from("projects")
+    .select(
+      `
+    id,name,description,lat,lng,status,created_at,
+    lead_org_id,
+    start_date,end_date,thematic_area,donations_received,amount_needed,currency,
+    approved_at,approved_by,rejected_at,rejected_by,rejection_reason
+  `
+    )
+    .eq("id", id)
+    .single();
+
+  if (error) throw error;
+  if (!project) return notFound();
+
+  const metadata: { label: string; value: string | null }[] = [
+    { label: "Status", value: project.status },
+    { label: "Created", value: new Date(project.created_at).toLocaleString() },
+    { label: "Lead Org", value: project.lead_org_id },
+    {
+      label: "Timeline",
+      value:
+        project.start_date || project.end_date
+          ? [project.start_date, project.end_date].filter(Boolean).join(" → ")
+          : null,
+    },
+    { label: "Thematic Area", value: project.thematic_area },
+    {
+      label: "Funding",
+      value:
+        project.amount_needed || project.donations_received
+          ? `${project.currency ?? ""} ${project.donations_received ?? 0} raised / ${project.amount_needed ?? "?"}`
+          : null,
+    },
+    { label: "Approved By", value: project.approved_by },
+    {
+      label: "Approved At",
+      value: project.approved_at ? new Date(project.approved_at).toLocaleString() : null,
+    },
+    { label: "Rejected By", value: project.rejected_by },
+    {
+      label: "Rejected At",
+      value: project.rejected_at ? new Date(project.rejected_at).toLocaleString() : null,
+    },
+    { label: "Rejection Reason", value: project.rejection_reason },
+  ];
+
+  const hasLocation = typeof project.lat === "number" && typeof project.lng === "number";
+
+  return (
+    <main className="space-y-6 p-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">{project.name}</h1>
+          <p className="text-sm text-gray-600">Project ID: {project.id}</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <form action={`/api/admin/projects/${project.id}/approve`} method="post">
+            <button className="rounded border px-4 py-2 hover:bg-gray-50">Approve</button>
+          </form>
+          <form
+            action={`/api/admin/projects/${project.id}/reject`}
+            method="post"
+            className="flex gap-2"
+          >
+            <input
+              name="reason"
+              placeholder="Reason"
+              className="rounded border px-3 py-2"
+              required
+            />
+            <button className="rounded border px-4 py-2 hover:bg-gray-50">Reject</button>
+          </form>
+          <Link
+            href="/admin/projects"
+            className="rounded border px-4 py-2 hover:bg-gray-50"
+          >
+            Back to list
+          </Link>
+        </div>
+      </div>
+
+      <section className="rounded-xl border p-4">
+        <h2 className="mb-3 text-lg font-medium">Metadata</h2>
+        <dl className="grid gap-3 sm:grid-cols-2">
+          {metadata
+            .filter(item => item.value)
+            .map(item => (
+              <div key={item.label}>
+                <dt className="text-xs uppercase tracking-wide text-gray-500">
+                  {item.label}
+                </dt>
+                <dd className="text-sm text-gray-900">{item.value}</dd>
+              </div>
+            ))}
+        </dl>
+      </section>
+
+      {hasLocation && (
+        <section className="rounded-xl border p-4">
+          <h2 className="mb-3 text-lg font-medium">Location</h2>
+          <p className="mb-3 text-sm text-gray-600">
+            Coordinates: {project.lat?.toFixed(4)}, {project.lng?.toFixed(4)}
+          </p>
+          <div className="h-64 overflow-hidden rounded-lg">
+            <Map
+              markers={[
+                {
+                  id: project.id,
+                  lat: project.lat as number,
+                  lng: project.lng as number,
+                  title: project.name,
+                },
+              ]}
+            />
+          </div>
+        </section>
+      )}
+
+      <section className="rounded-xl border p-4">
+        <h2 className="mb-3 text-lg font-medium">Description</h2>
+        <p className="whitespace-pre-line text-sm leading-relaxed text-gray-800">
+          {project.description || "No description provided."}
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/src/app/admin/projects/page.tsx
+++ b/src/app/admin/projects/page.tsx
@@ -1,0 +1,105 @@
+import Link from "next/link";
+import { getServerSupabase } from "@/lib/supabaseServer";
+
+export default async function AdminProjectsPage() {
+  const supabase = await getServerSupabase();
+  const { data: isAdmin } = await supabase.rpc("is_admin");
+  if (!isAdmin) return new Response(null, { status: 404 }) as never;
+
+  const { data: projects, error } = await supabase
+    .from("projects")
+    .select(
+      "id,name,description,lat,lng,created_at,status,lead_org_id,approved_at,approved_by,rejected_at,rejected_by,rejection_reason"
+    )
+    .eq("status", "pending")
+    .order("created_at", { ascending: false });
+
+  if (error) throw error;
+
+  return (
+    <main className="p-6">
+      <div className="mb-4 flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Pending Projects</h1>
+        <p className="text-sm text-gray-600">
+          Review newly submitted projects and approve or reject them.
+        </p>
+      </div>
+      <div className="overflow-auto rounded-xl border">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-50">
+            <tr>
+              {["Created", "Name", "Location", "Excerpt", "Actions"].map(header => (
+                <th key={header} className="px-4 py-2 text-left">
+                  {header}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {projects?.length ? (
+              projects.map(project => {
+                const created = new Date(project.created_at).toLocaleString();
+                const excerpt = project.description?.slice(0, 120) ?? "";
+                const location =
+                  project.lat && project.lng
+                    ? `${project.lat.toFixed(4)}, ${project.lng.toFixed(4)}`
+                    : "—";
+
+                return (
+                  <tr key={project.id} className="border-t align-top">
+                    <td className="px-4 py-2 whitespace-nowrap">{created}</td>
+                    <td className="px-4 py-2">
+                      <div className="font-medium">
+                        <Link
+                          href={`/admin/projects/${project.id}`}
+                          className="hover:underline"
+                        >
+                          {project.name}
+                        </Link>
+                      </div>
+                      <div className="text-xs text-gray-500">ID: {project.id}</div>
+                    </td>
+                    <td className="px-4 py-2 whitespace-nowrap">{location}</td>
+                    <td className="px-4 py-2">{excerpt}{project.description && project.description.length > 120 ? "…" : ""}</td>
+                    <td className="px-4 py-2">
+                      <form
+                        action={`/api/admin/projects/${project.id}/approve`}
+                        method="post"
+                        className="mb-2"
+                      >
+                        <button className="w-full rounded border px-3 py-1 hover:bg-gray-50">
+                          Approve
+                        </button>
+                      </form>
+                      <form
+                        action={`/api/admin/projects/${project.id}/reject`}
+                        method="post"
+                        className="flex flex-col gap-2 sm:flex-row"
+                      >
+                        <input
+                          name="reason"
+                          placeholder="Reason"
+                          className="flex-1 rounded border px-2 py-1"
+                          required
+                        />
+                        <button className="rounded border px-3 py-1 hover:bg-gray-50">
+                          Reject
+                        </button>
+                      </form>
+                    </td>
+                  </tr>
+                );
+              })
+            ) : (
+              <tr>
+                <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-500">
+                  No pending projects at the moment.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </main>
+  );
+}

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -45,13 +45,22 @@ export default function UserMenu({ onNavigate }: { onNavigate?: () => void }) {
         Settings
       </Link>
       {isAdmin && (
-        <Link
-          href="/admin/registrations"
-          className="px-4 py-2 hover:bg-white/10"
-          onClick={onNavigate}
-        >
-          Project Registrations
-        </Link>
+        <>
+          <Link
+            href="/admin/projects"
+            className="px-4 py-2 hover:bg-white/10"
+            onClick={onNavigate}
+          >
+            Pending Projects
+          </Link>
+          <Link
+            href="/admin/registrations"
+            className="px-4 py-2 hover:bg-white/10"
+            onClick={onNavigate}
+          >
+            Project Registrations
+          </Link>
+        </>
       )}
       {isSuper && (
         <Link


### PR DESCRIPTION
## Summary
- add an admin listing for pending projects with inline approve/reject actions
- create a detailed admin project review page with metadata, location, and review controls
- expose a Pending Projects entry in the user menu for admins

## Testing
- pnpm lint
- pnpm build *(fails: missing Supabase credentials in env during prerender)*

------
https://chatgpt.com/codex/tasks/task_e_68dda4d230108326bf58d5a165100ad4