### PR TITLE
Handle Supabase errors with issue-aware formatting

### DIFF
--- a/src/app/api/admin/projects/[id]/approve/route.ts
+++ b/src/app/api/admin/projects/[id]/approve/route.ts
@@ -1,6 +1,29 @@
 import { NextResponse } from "next/server";
 import { getServerSupabase } from "@/lib/supabaseServer";
 
+type IssueLike = { message?: string | undefined };
+
+const formatErrorMessage = (error: unknown): string => {
+  if (typeof error === "object" && error !== null) {
+    const issues = (error as { issues?: IssueLike[] }).issues;
+    if (Array.isArray(issues)) {
+      const messages = issues
+        .map(issue => issue?.message)
+        .filter((message): message is string => Boolean(message && message.trim().length));
+      if (messages.length > 0) {
+        return messages.join(", ");
+      }
+    }
+
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string" && message.trim().length) {
+      return message;
+    }
+  }
+
+  return "Unknown error";
+};
+
 export async function POST(
   _: Request,
   { params }: { params: Promise<{ id: string }> },
@@ -17,6 +40,8 @@ export async function POST(
     .eq("id", id)
     .select()
     .single();
-  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+  if (error) {
+    return NextResponse.json({ error: formatErrorMessage(error) }, { status: 400 });
+  }
   return NextResponse.json({ data });
 }

--- a/src/app/api/admin/projects/[id]/reject/route.ts
+++ b/src/app/api/admin/projects/[id]/reject/route.ts
@@ -1,6 +1,29 @@
 import { NextResponse } from "next/server";
 import { getServerSupabase } from "@/lib/supabaseServer";
 
+type IssueLike = { message?: string | undefined };
+
+const formatErrorMessage = (error: unknown): string => {
+  if (typeof error === "object" && error !== null) {
+    const issues = (error as { issues?: IssueLike[] }).issues;
+    if (Array.isArray(issues)) {
+      const messages = issues
+        .map(issue => issue?.message)
+        .filter((message): message is string => Boolean(message && message.trim().length));
+      if (messages.length > 0) {
+        return messages.join(", ");
+      }
+    }
+
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string" && message.trim().length) {
+      return message;
+    }
+  }
+
+  return "Unknown error";
+};
+
 export async function POST(
   req: Request,
   { params }: { params: Promise<{ id: string }> },
@@ -19,6 +42,8 @@ export async function POST(
     .eq("id", id)
     .select()
     .single();
-  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+  if (error) {
+    return NextResponse.json({ error: formatErrorMessage(error) }, { status: 400 });
+  }
   return NextResponse.json({ data });
 }


### PR DESCRIPTION
## Summary
- add shared issue-based error formatting helpers in the admin project approval and rejection routes
- ensure Supabase errors fall back to message strings when no issues are present

## Testing
- pnpm lint
- pnpm build *(fails: Supabase URL/API key env vars are required for prerendering)*

------
https://chatgpt.com/codex/tasks/task_e_68e29021374c8326ae6ffc8643ff90e1