### PR TITLE
Restore admin project approvals workflow

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,61 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { getServerSupabase } from "@/lib/supabaseServer";
+
+export default async function AdminIndexPage() {
+  const supabase = await getServerSupabase();
+  const { data: isAdmin } = await supabase.rpc("is_admin");
+
+  if (!isAdmin) {
+    notFound();
+  }
+
+  const { data: isSuper } = await supabase.rpc("is_superadmin");
+
+  const links = [
+    {
+      href: "/admin/projects",
+      title: "Project approvals",
+      description: "Review pending project submissions and manage their status.",
+    },
+    {
+      href: "/admin/registrations",
+      title: "Registrations",
+      description: "Check organisation and user onboarding requests.",
+    },
+  ];
+
+  if (isSuper) {
+    links.push({
+      href: "/admin/manage",
+      title: "Admin settings",
+      description: "Add or remove admins and adjust permissions.",
+    });
+  }
+
+  return (
+    <main className="space-y-6 p-6">
+      <div className="space-y-1">
+        <h1 className="text-3xl font-semibold text-slate-900">Admin dashboard</h1>
+        <p className="text-sm text-slate-500">
+          Access moderation and configuration tools for the Solarpunk Taskforce platform.
+        </p>
+      </div>
+
+      <ul className="grid gap-4 sm:grid-cols-2">
+        {links.map(link => (
+          <li key={link.href} className="rounded-xl border p-4 shadow-sm transition hover:shadow-md">
+            <Link href={link.href} className="block space-y-2">
+              <div className="space-y-1">
+                <h2 className="text-lg font-semibold text-slate-900">{link.title}</h2>
+                <p className="text-sm text-slate-600">{link.description}</p>
+              </div>
+              <span className="text-sm font-medium text-emerald-600">Go to {link.title.toLowerCase()}</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/src/app/admin/projects/[id]/page.tsx
+++ b/src/app/admin/projects/[id]/page.tsx
@@ -1,7 +1,102 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { getServerSupabase } from "@/lib/supabaseServer";
+
+import { ProjectApprovalActions } from "@/components/admin/ProjectApprovalActions";
 import Map from "@/components/Map";
+import type { Database } from "@/lib/database.types";
+import { getServerSupabase } from "@/lib/supabaseServer";
+
+type ProjectRow = Database["public"]["Tables"]["projects"]["Row"];
+type ProfileRow = Database["public"]["Tables"]["profiles"]["Row"];
+type ProjectLinksRow = Database["public"]["Tables"]["project_links"]["Row"];
+type ProjectMediaRow = Database["public"]["Tables"]["project_media"]["Row"];
+type ProjectPartnersRow = Database["public"]["Tables"]["project_partners"]["Row"];
+type ProjectSdgsRow = Database["public"]["Tables"]["project_sdgs"]["Row"];
+type ProjectIfrcRow = Database["public"]["Tables"]["project_ifrc_challenges"]["Row"];
+type OrganisationRow = Database["public"]["Tables"]["organisations"]["Row"];
+type SdgRow = Database["public"]["Tables"]["sdgs"]["Row"];
+type IfrcChallengeRow = Database["public"]["Tables"]["ifrc_challenges"]["Row"];
+
+type ProjectDetail = ProjectRow & {
+  created_by_profile: Pick<ProfileRow, "full_name" | "organisation_name" | "role"> | null;
+  project_links: (Pick<ProjectLinksRow, "id" | "label" | "url"> & {
+    created_at?: string | null;
+  })[];
+  project_media: (Pick<ProjectMediaRow, "id" | "path" | "caption" | "mime_type"> & {
+    created_at?: string | null;
+  })[];
+  project_partners: (Pick<ProjectPartnersRow, "organisation_id"> & {
+    organisation: Pick<OrganisationRow, "id" | "name"> | null;
+  })[];
+  project_sdgs: (Pick<ProjectSdgsRow, "sdg_id"> & {
+    sdg: Pick<SdgRow, "id" | "name"> | null;
+  })[];
+  project_ifrc_challenges: (Pick<ProjectIfrcRow, "challenge_id"> & {
+    challenge: Pick<IfrcChallengeRow, "id" | "name" | "code"> | null;
+  })[];
+};
+
+type RawProjectDetail = Omit<ProjectDetail, "created_by_profile"> & {
+  created_by_profile: Pick<
+    ProfileRow,
+    "full_name" | "organisation_name" | "role"
+  >[] | null;
+};
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return "—";
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    }).format(new Date(value));
+  } catch (error) {
+    console.error("date-format", error);
+    return value;
+  }
+}
+
+function formatDateTime(value: string | null | undefined) {
+  if (!value) return "—";
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(new Date(value));
+  } catch (error) {
+    console.error("datetime-format", error);
+    return value;
+  }
+}
+
+function formatCurrency(amount: number | null, currency: string | null) {
+  if (typeof amount !== "number") return null;
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency: currency ?? "USD",
+      maximumFractionDigits: 0,
+    }).format(amount);
+  } catch (error) {
+    console.error("currency-format", error);
+    return currency ? `${currency} ${amount}` : `${amount}`;
+  }
+}
+
+function parseJsonLinks(value: ProjectRow["links"]) {
+  if (!value) return [] as { label?: string | null; url?: string | null }[];
+  if (Array.isArray(value)) {
+    return value as { label?: string | null; url?: string | null }[];
+  }
+  if (typeof value === "object" && value !== null) {
+    return Object.values(value) as { label?: string | null; url?: string | null }[];
+  }
+  return [];
+}
 
 export default async function AdminProjectDetail({
   params,
@@ -11,114 +106,281 @@ export default async function AdminProjectDetail({
   const supabase = await getServerSupabase();
   const { id } = await params;
   const { data: isAdmin } = await supabase.rpc("is_admin");
-  if (!isAdmin) return new Response(null, { status: 404 }) as never;
 
-  const { data: project, error } = await supabase
+  if (!isAdmin) {
+    notFound();
+  }
+
+  const { data, error } = await supabase
     .from("projects")
     .select(
+      `*,
+       project_links:project_links(id,label,url,created_at),
+       project_media:project_media(id,path,caption,mime_type,created_at),
+       project_partners:project_partners(organisation_id,organisation:organisations(id,name)),
+       project_sdgs:project_sdgs(sdg_id,sdg:sdgs(id,name)),
+       project_ifrc_challenges:project_ifrc_challenges(challenge_id,challenge:ifrc_challenges(id,name,code)),
+       created_by_profile:profiles(full_name,organisation_name,role)
       `
-    id,name,description,lat,lng,status,created_at,
-    lead_org_id,
-    start_date,end_date,thematic_area,donations_received,amount_needed,currency,
-    approved_at,approved_by,rejected_at,rejected_by,rejection_reason
-  `
     )
     .eq("id", id)
     .single();
 
-  if (error) throw error;
-  if (!project) return notFound();
+  if (error) {
+    throw error;
+  }
 
-  const metadata: { label: string; value: string | null }[] = [
-    { label: "Status", value: project.status },
-    { label: "Created", value: new Date(project.created_at).toLocaleString() },
-    { label: "Lead Org", value: project.lead_org_id },
-    {
-      label: "Timeline",
-      value:
-        project.start_date || project.end_date
-          ? [project.start_date, project.end_date].filter(Boolean).join(" → ")
-          : null,
-    },
-    { label: "Thematic Area", value: project.thematic_area },
-    {
-      label: "Funding",
-      value:
-        project.amount_needed || project.donations_received
-          ? `${project.currency ?? ""} ${project.donations_received ?? 0} raised / ${project.amount_needed ?? "?"}`
-          : null,
-    },
-    { label: "Approved By", value: project.approved_by },
-    {
-      label: "Approved At",
-      value: project.approved_at ? new Date(project.approved_at).toLocaleString() : null,
-    },
-    { label: "Rejected By", value: project.rejected_by },
-    {
-      label: "Rejected At",
-      value: project.rejected_at ? new Date(project.rejected_at).toLocaleString() : null,
-    },
-    { label: "Rejection Reason", value: project.rejection_reason },
-  ];
+  if (!data) {
+    notFound();
+  }
 
+  const rawProject = data as RawProjectDetail;
+
+  const project: ProjectDetail = {
+    ...rawProject,
+    created_by_profile: rawProject.created_by_profile?.[0] ?? null,
+    project_links: rawProject.project_links ?? [],
+    project_media: rawProject.project_media ?? [],
+    project_partners: rawProject.project_partners ?? [],
+    project_sdgs: rawProject.project_sdgs ?? [],
+    project_ifrc_challenges: rawProject.project_ifrc_challenges ?? [],
+  };
+  const jsonLinks = parseJsonLinks(project.links);
   const hasLocation = typeof project.lat === "number" && typeof project.lng === "number";
+
+  const fundingParts = [
+    formatCurrency(project.donations_received, project.currency)
+      ? `Raised ${formatCurrency(project.donations_received, project.currency)}`
+      : null,
+    formatCurrency(project.amount_needed, project.currency)
+      ? `Needed ${formatCurrency(project.amount_needed, project.currency)}`
+      : null,
+  ].filter(Boolean);
+
+  const createdBy = project.created_by_profile?.full_name
+    ?? project.created_by_profile?.organisation_name
+    ?? project.created_by
+    ?? "Unknown";
 
   return (
     <main className="space-y-6 p-6">
-      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold">{project.name}</h1>
-          <p className="text-sm text-gray-600">Project ID: {project.id}</p>
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-1">
+          <h1 className="text-3xl font-semibold text-slate-900">{project.name}</h1>
+          <p className="text-sm text-slate-500">
+            Created {formatDateTime(project.created_at)} by {createdBy}
+          </p>
+          <p className="text-xs text-slate-500">
+            Project ID: {project.id}
+          </p>
         </div>
-        <div className="flex flex-wrap gap-2">
-          <form action={`/api/admin/projects/${project.id}/approve`} method="post">
-            <button className="rounded border px-4 py-2 hover:bg-gray-50">Approve</button>
-          </form>
-          <form
-            action={`/api/admin/projects/${project.id}/reject`}
-            method="post"
-            className="flex gap-2"
-          >
-            <input
-              name="reason"
-              placeholder="Reason"
-              className="rounded border px-3 py-2"
-              required
-            />
-            <button className="rounded border px-4 py-2 hover:bg-gray-50">Reject</button>
-          </form>
-          <Link
-            href="/admin/projects"
-            className="rounded border px-4 py-2 hover:bg-gray-50"
-          >
-            Back to list
-          </Link>
-        </div>
+        <ProjectApprovalActions projectId={project.id} projectName={project.name} layout="inline" />
       </div>
 
       <section className="rounded-xl border p-4">
-        <h2 className="mb-3 text-lg font-medium">Metadata</h2>
-        <dl className="grid gap-3 sm:grid-cols-2">
-          {metadata
-            .filter(item => item.value)
-            .map(item => (
-              <div key={item.label}>
-                <dt className="text-xs uppercase tracking-wide text-gray-500">
-                  {item.label}
-                </dt>
-                <dd className="text-sm text-gray-900">{item.value}</dd>
-              </div>
-            ))}
+        <h2 className="mb-3 text-lg font-semibold text-slate-900">Overview</h2>
+        <dl className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Status
+            </dt>
+            <dd className="text-sm text-slate-900">{project.status}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Lifecycle status
+            </dt>
+            <dd className="text-sm text-slate-900">{project.lifecycle_status ?? "—"}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Review status
+            </dt>
+            <dd className="text-sm text-slate-900">{project.review_status ?? "—"}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Location
+            </dt>
+            <dd className="text-sm text-slate-900">
+              {[project.place_name, project.region, project.country]
+                .filter(Boolean)
+                .join(", ") || "—"}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Timeline
+            </dt>
+            <dd className="text-sm text-slate-900">
+              {[formatDate(project.start_date), formatDate(project.end_date)]
+                .filter(value => value !== "—")
+                .join(" → ") || "—"}
+            </dd>
+          </div>
+          <div>
+            <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Funding
+            </dt>
+            <dd className="text-sm text-slate-900">
+              {fundingParts.length ? fundingParts.join(" · ") : "—"}
+            </dd>
+          </div>
         </dl>
       </section>
 
-      {hasLocation && (
+      <section className="rounded-xl border p-4">
+        <h2 className="mb-3 text-lg font-semibold text-slate-900">Description</h2>
+        <p className="whitespace-pre-line text-sm leading-relaxed text-slate-700">
+          {project.description || "No description provided."}
+        </p>
+      </section>
+
+      <section className="rounded-xl border p-4">
+        <h2 className="mb-3 text-lg font-semibold text-slate-900">Links</h2>
+        <div className="space-y-2 text-sm">
+          {project.project_links.length === 0 && jsonLinks.length === 0 ? (
+            <p className="text-slate-500">No links submitted.</p>
+          ) : (
+            <ul className="space-y-2">
+              {project.project_links.map(link => (
+                <li key={link.id}>
+                  <a
+                    href={link.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-emerald-600 hover:underline"
+                  >
+                    {link.label || link.url}
+                  </a>
+                </li>
+              ))}
+              {jsonLinks.map((link, index) => (
+                <li key={`json-${index}`}>
+                  {link?.url ? (
+                    <a
+                      href={link.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-emerald-600 hover:underline"
+                    >
+                      {link.label || link.url}
+                    </a>
+                  ) : (
+                    <span className="text-slate-500">{link.label}</span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-xl border p-4">
+        <h2 className="mb-3 text-lg font-semibold text-slate-900">Partners</h2>
+        {project.project_partners.length === 0 && !project.partner_org_ids?.length ? (
+          <p className="text-sm text-slate-500">No partner organisations listed.</p>
+        ) : (
+          <ul className="space-y-1 text-sm">
+            {project.project_partners.map(partner => (
+              <li key={partner.organisation_id}>
+                {partner.organisation?.name ?? partner.organisation_id}
+              </li>
+            ))}
+            {project.partner_org_ids?.map(id => (
+              <li key={`fallback-${id}`}>{id}</li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="rounded-xl border p-4">
+        <h2 className="mb-3 text-lg font-semibold text-slate-900">Sustainable Development Goals</h2>
+        {project.project_sdgs.length === 0 && !project.sdgs?.length ? (
+          <p className="text-sm text-slate-500">No SDGs specified.</p>
+        ) : (
+          <div className="flex flex-wrap gap-2 text-sm">
+            {project.project_sdgs.map(item => (
+              <span
+                key={item.sdg_id}
+                className="rounded-full bg-emerald-50 px-3 py-1 text-emerald-700"
+              >
+                {item.sdg?.name ?? `SDG ${item.sdg_id}`}
+              </span>
+            ))}
+            {project.sdgs?.map(code => (
+              <span
+                key={`sdg-${code}`}
+                className="rounded-full bg-emerald-50 px-3 py-1 text-emerald-700"
+              >
+                {code}
+              </span>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="rounded-xl border p-4">
+        <h2 className="mb-3 text-lg font-semibold text-slate-900">IFRC Global Challenges</h2>
+        {project.project_ifrc_challenges.length === 0 && !project.ifrc_global_challenges?.length ? (
+          <p className="text-sm text-slate-500">No IFRC challenges specified.</p>
+        ) : (
+          <div className="flex flex-wrap gap-2 text-sm">
+            {project.project_ifrc_challenges.map(item => (
+              <span
+                key={item.challenge_id}
+                className="rounded-full bg-amber-50 px-3 py-1 text-amber-700"
+              >
+                {item.challenge?.name ?? item.challenge?.code ?? `Challenge ${item.challenge_id}`}
+              </span>
+            ))}
+            {project.ifrc_global_challenges?.map(code => (
+              <span
+                key={`ifrc-${code}`}
+                className="rounded-full bg-amber-50 px-3 py-1 text-amber-700"
+              >
+                {code}
+              </span>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="rounded-xl border p-4">
+        <h2 className="mb-3 text-lg font-semibold text-slate-900">Media</h2>
+        {project.project_media.length === 0 ? (
+          <p className="text-sm text-slate-500">No media uploaded.</p>
+        ) : (
+          <ul className="space-y-2 text-sm">
+            {project.project_media.map(item => (
+              <li key={item.id} className="flex items-center justify-between gap-2">
+                <div>
+                  <div className="font-medium text-slate-900">{item.caption || item.path}</div>
+                  <div className="text-xs text-slate-500">
+                    {item.mime_type || "Unknown type"} · {formatDateTime(item.created_at)}
+                  </div>
+                </div>
+                <Link
+                  href={item.path}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-xs font-medium text-emerald-600 hover:underline"
+                >
+                  View
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      {hasLocation ? (
         <section className="rounded-xl border p-4">
-          <h2 className="mb-3 text-lg font-medium">Location</h2>
-          <p className="mb-3 text-sm text-gray-600">
+          <h2 className="mb-3 text-lg font-semibold text-slate-900">Location</h2>
+          <p className="mb-3 text-sm text-slate-500">
             Coordinates: {project.lat?.toFixed(4)}, {project.lng?.toFixed(4)}
           </p>
-          <div className="h-64 overflow-hidden rounded-lg">
+          <div className="h-64 overflow-hidden rounded-lg border">
             <Map
               markers={[
                 {
@@ -131,14 +393,13 @@ export default async function AdminProjectDetail({
             />
           </div>
         </section>
-      )}
+      ) : null}
 
-      <section className="rounded-xl border p-4">
-        <h2 className="mb-3 text-lg font-medium">Description</h2>
-        <p className="whitespace-pre-line text-sm leading-relaxed text-gray-800">
-          {project.description || "No description provided."}
-        </p>
-      </section>
+      <div>
+        <Link href="/admin/projects" className="text-sm font-medium text-emerald-600 hover:underline">
+          ← Back to approvals
+        </Link>
+      </div>
     </main>
   );
 }

--- a/src/app/admin/projects/page.tsx
+++ b/src/app/admin/projects/page.tsx
@@ -1,101 +1,164 @@
 import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { ProjectApprovalActions } from "@/components/admin/ProjectApprovalActions";
+import type { Database } from "@/lib/database.types";
 import { getServerSupabase } from "@/lib/supabaseServer";
+
+type ProjectRow = Database["public"]["Tables"]["projects"]["Row"];
+type ProfileRow = Database["public"]["Tables"]["profiles"]["Row"];
+type ProjectMediaRow = Database["public"]["Tables"]["project_media"]["Row"];
+type ProjectLinksRow = Database["public"]["Tables"]["project_links"]["Row"];
+
+type ProjectListItem = Pick<
+  ProjectRow,
+  "id" | "name" | "created_at" | "created_by" | "place_name" | "links"
+> & {
+  project_media: Pick<ProjectMediaRow, "id">[] | null;
+  project_links: Pick<ProjectLinksRow, "id">[] | null;
+  created_by_profile: Pick<ProfileRow, "full_name" | "organisation_name"> | null;
+};
+
+type RawProjectListItem = Omit<ProjectListItem, "created_by_profile"> & {
+  created_by_profile: Pick<ProfileRow, "full_name" | "organisation_name">[] | null;
+};
+
+function formatDate(value: string | null) {
+  if (!value) return "—";
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    }).format(new Date(value));
+  } catch (error) {
+    console.error("date-format", error);
+    return value;
+  }
+}
+
+function getLinksCount(project: ProjectListItem) {
+  if (Array.isArray(project.project_links)) {
+    return project.project_links.length;
+  }
+  const jsonValue = project.links;
+  if (Array.isArray(jsonValue)) {
+    return jsonValue.length;
+  }
+  return 0;
+}
+
+function getMediaCount(project: ProjectListItem) {
+  if (Array.isArray(project.project_media)) {
+    return project.project_media.length;
+  }
+  return 0;
+}
+
+function getCreatedBy(project: ProjectListItem) {
+  const profile = project.created_by_profile;
+  if (profile?.full_name) return profile.full_name;
+  if (profile?.organisation_name) return profile.organisation_name;
+  return project.created_by ?? "—";
+}
 
 export default async function AdminProjectsPage() {
   const supabase = await getServerSupabase();
   const { data: isAdmin } = await supabase.rpc("is_admin");
-  if (!isAdmin) return new Response(null, { status: 404 }) as never;
 
-  const { data: projects, error } = await supabase
+  if (!isAdmin) {
+    notFound();
+  }
+
+  const { data, error } = await supabase
     .from("projects")
     .select(
-      "id,name,description,lat,lng,created_at,status,lead_org_id,approved_at,approved_by,rejected_at,rejected_by,rejection_reason"
+      `id,name,created_at,created_by,place_name,links,
+       project_links:project_links(id),
+       project_media:project_media(id),
+       created_by_profile:profiles(full_name,organisation_name)
+      `
     )
     .eq("status", "pending")
-    .order("created_at", { ascending: false });
+    .order("created_at", { ascending: false })
+    .limit(50);
 
-  if (error) throw error;
+  if (error) {
+    throw error;
+  }
+
+  const projects: ProjectListItem[] = (data as RawProjectListItem[] | null)?.map(
+    project => ({
+      ...project,
+      created_by_profile: project.created_by_profile?.[0] ?? null,
+    })
+  ) ?? [];
 
   return (
-    <main className="p-6">
-      <div className="mb-4 flex items-center justify-between">
-        <h1 className="text-2xl font-semibold">Pending Projects</h1>
-        <p className="text-sm text-gray-600">
-          Review newly submitted projects and approve or reject them.
+    <main className="space-y-6 p-6">
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold">Project Approvals</h1>
+        <p className="text-sm text-slate-500">
+          Review the latest pending projects and approve or reject them.
         </p>
       </div>
-      <div className="overflow-auto rounded-xl border">
-        <table className="min-w-full text-sm">
-          <thead className="bg-gray-50">
+
+      <div className="overflow-x-auto rounded-xl border">
+        <table className="min-w-full divide-y text-sm">
+          <thead className="bg-slate-50 text-left text-xs uppercase tracking-wide text-slate-500">
             <tr>
-              {["Created", "Name", "Location", "Excerpt", "Actions"].map(header => (
-                <th key={header} className="px-4 py-2 text-left">
-                  {header}
-                </th>
-              ))}
+              <th className="px-4 py-3">Name</th>
+              <th className="px-4 py-3">Created</th>
+              <th className="px-4 py-3">Created by</th>
+              <th className="px-4 py-3">Location</th>
+              <th className="px-4 py-3">Links</th>
+              <th className="px-4 py-3">Media</th>
+              <th className="px-4 py-3">Actions</th>
             </tr>
           </thead>
-          <tbody>
-            {projects?.length ? (
+          <tbody className="divide-y">
+            {projects.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="px-4 py-8 text-center text-sm text-slate-500">
+                  No pending projects right now.
+                </td>
+              </tr>
+            ) : (
               projects.map(project => {
-                const created = new Date(project.created_at).toLocaleString();
-                const excerpt = project.description?.slice(0, 120) ?? "";
-                const location =
-                  project.lat && project.lng
-                    ? `${project.lat.toFixed(4)}, ${project.lng.toFixed(4)}`
-                    : "—";
-
+                const created = formatDate(project.created_at);
+                const linksCount = getLinksCount(project);
+                const mediaCount = getMediaCount(project);
                 return (
-                  <tr key={project.id} className="border-t align-top">
-                    <td className="px-4 py-2 whitespace-nowrap">{created}</td>
-                    <td className="px-4 py-2">
-                      <div className="font-medium">
-                        <Link
-                          href={`/admin/projects/${project.id}`}
-                          className="hover:underline"
-                        >
-                          {project.name}
-                        </Link>
-                      </div>
-                      <div className="text-xs text-gray-500">ID: {project.id}</div>
+                  <tr key={project.id} className="align-top">
+                    <td className="px-4 py-3">
+                      <div className="font-medium text-slate-900">{project.name}</div>
+                      <div className="text-xs text-slate-500">{project.id}</div>
+                      <Link
+                        href={`/admin/projects/${project.id}`}
+                        className="mt-2 inline-flex text-xs font-medium text-emerald-600 hover:underline"
+                      >
+                        View details
+                      </Link>
                     </td>
-                    <td className="px-4 py-2 whitespace-nowrap">{location}</td>
-                    <td className="px-4 py-2">{excerpt}{project.description && project.description.length > 120 ? "…" : ""}</td>
-                    <td className="px-4 py-2">
-                      <form
-                        action={`/api/admin/projects/${project.id}/approve`}
-                        method="post"
-                        className="mb-2"
-                      >
-                        <button className="w-full rounded border px-3 py-1 hover:bg-gray-50">
-                          Approve
-                        </button>
-                      </form>
-                      <form
-                        action={`/api/admin/projects/${project.id}/reject`}
-                        method="post"
-                        className="flex flex-col gap-2 sm:flex-row"
-                      >
-                        <input
-                          name="reason"
-                          placeholder="Reason"
-                          className="flex-1 rounded border px-2 py-1"
-                          required
-                        />
-                        <button className="rounded border px-3 py-1 hover:bg-gray-50">
-                          Reject
-                        </button>
-                      </form>
+                    <td className="px-4 py-3 whitespace-nowrap">{created}</td>
+                    <td className="px-4 py-3 whitespace-nowrap">{getCreatedBy(project)}</td>
+                    <td className="px-4 py-3 whitespace-nowrap">
+                      {project.place_name ?? "—"}
+                    </td>
+                    <td className="px-4 py-3 whitespace-nowrap">{linksCount}</td>
+                    <td className="px-4 py-3 whitespace-nowrap">{mediaCount}</td>
+                    <td className="px-4 py-3">
+                      <ProjectApprovalActions
+                        projectId={project.id}
+                        projectName={project.name}
+                        layout="inline"
+                      />
                     </td>
                   </tr>
                 );
               })
-            ) : (
-              <tr>
-                <td colSpan={5} className="px-4 py-8 text-center text-sm text-gray-500">
-                  No pending projects at the moment.
-                </td>
-              </tr>
             )}
           </tbody>
         </table>

--- a/src/app/api/admin/projects/approve/route.ts
+++ b/src/app/api/admin/projects/approve/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import type { Database } from "@/lib/database.types";
+import { getServerSupabase } from "@/lib/supabaseServer";
+
+const payloadSchema = z.object({
+  id: z.string().min(1, "Project id is required."),
+});
+
+type ProjectRow = Database["public"]["Tables"]["projects"]["Row"];
+
+type ProjectUpdate = Pick<ProjectRow, "id" | "status" | "approved_at" | "approved_by">;
+
+export async function POST(request: Request) {
+  const supabase = await getServerSupabase();
+  const { data: isAdmin } = await supabase.rpc("is_admin");
+
+  if (!isAdmin) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  let payload: z.infer<typeof payloadSchema>;
+
+  try {
+    const json = await request.json();
+    payload = payloadSchema.parse(json);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      const message = error.issues.map(issue => issue.message).join(" ") || "Invalid request.";
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+    return NextResponse.json({ error: "Invalid request body." }, { status: 400 });
+  }
+
+  const { data: auth } = await supabase.auth.getUser();
+  const approverId = auth?.user?.id ?? null;
+
+  const { data, error } = await supabase
+    .from("projects")
+    .update({
+      status: "approved",
+      approved_by: approverId,
+      approved_at: new Date().toISOString(),
+    })
+    .eq("id", payload.id)
+    .select("id,status,approved_by,approved_at")
+    .single();
+
+  if (error) {
+    if (error.code === "PGRST116") {
+      return NextResponse.json({ error: "Project not found." }, { status: 404 });
+    }
+
+    if (error.code === "42501") {
+      return NextResponse.json({ error: "Not authorised." }, { status: 403 });
+    }
+
+    if (error.code === "23514") {
+      return NextResponse.json({ error: "Project cannot be approved." }, { status: 400 });
+    }
+
+    // TODO: If RLS prevents admin updates here, revisit policies.
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ data: data as ProjectUpdate });
+}

--- a/src/app/api/admin/projects/reject/route.ts
+++ b/src/app/api/admin/projects/reject/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import type { Database } from "@/lib/database.types";
+import { getServerSupabase } from "@/lib/supabaseServer";
+
+const payloadSchema = z.object({
+  id: z.string().min(1, "Project id is required."),
+  reason: z.string().max(500).optional(),
+});
+
+type ProjectRow = Database["public"]["Tables"]["projects"]["Row"];
+
+type ProjectUpdate = Pick<ProjectRow, "id" | "status" | "rejected_at" | "rejected_by" | "rejection_reason">;
+
+export async function POST(request: Request) {
+  const supabase = await getServerSupabase();
+  const { data: isAdmin } = await supabase.rpc("is_admin");
+
+  if (!isAdmin) {
+    return NextResponse.json({ error: "forbidden" }, { status: 403 });
+  }
+
+  let payload: z.infer<typeof payloadSchema>;
+
+  try {
+    const json = await request.json();
+    payload = payloadSchema.parse(json);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      const message = error.issues.map(issue => issue.message).join(" ") || "Invalid request.";
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+    return NextResponse.json({ error: "Invalid request body." }, { status: 400 });
+  }
+
+  const { data: auth } = await supabase.auth.getUser();
+  const reviewerId = auth?.user?.id ?? null;
+
+  const { data, error } = await supabase
+    .from("projects")
+    .update({
+      status: "rejected",
+      rejection_reason: payload.reason ?? null,
+      rejected_by: reviewerId,
+      rejected_at: new Date().toISOString(),
+    })
+    .eq("id", payload.id)
+    .select("id,status,rejected_by,rejected_at,rejection_reason")
+    .single();
+
+  if (error) {
+    if (error.code === "PGRST116") {
+      return NextResponse.json({ error: "Project not found." }, { status: 404 });
+    }
+
+    if (error.code === "42501") {
+      return NextResponse.json({ error: "Not authorised." }, { status: 403 });
+    }
+
+    // TODO: If RLS prevents admin updates here, revisit policies.
+    return NextResponse.json({ error: error.message }, { status: 400 });
+  }
+
+  return NextResponse.json({ data: data as ProjectUpdate });
+}

--- a/src/components/admin/ProjectApprovalActions.tsx
+++ b/src/components/admin/ProjectApprovalActions.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+type Action = "approve" | "reject";
+
+type Message = {
+  kind: "success" | "error";
+  text: string;
+};
+
+type Props = {
+  projectId: string;
+  projectName?: string;
+  layout?: "stacked" | "inline";
+  className?: string;
+};
+
+export function ProjectApprovalActions({
+  projectId,
+  projectName,
+  layout = "stacked",
+  className,
+}: Props) {
+  const router = useRouter();
+  const [message, setMessage] = useState<Message | null>(null);
+  const [pendingAction, setPendingAction] = useState<Action | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const disabled = isPending || pendingAction !== null;
+
+  function runAction(action: Action, extra?: Record<string, unknown>) {
+    setMessage(null);
+    setPendingAction(action);
+    startTransition(async () => {
+      try {
+        const response = await fetch(`/api/admin/projects/${action}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ id: projectId, ...extra }),
+        });
+
+        if (!response.ok) {
+          const body = await response.json().catch(() => null);
+          const errorMessage =
+            typeof body?.error === "string"
+              ? body.error
+              : `Unable to ${action} project.`;
+          setMessage({ kind: "error", text: errorMessage });
+          return;
+        }
+
+        setMessage({
+          kind: "success",
+          text: `Project ${projectName ? `“${projectName}” ` : ""}${
+            action === "approve" ? "approved" : "rejected"
+          }.`,
+        });
+        router.refresh();
+      } catch (error) {
+        console.error(error);
+        setMessage({ kind: "error", text: "Unexpected error. Please try again." });
+      } finally {
+        setPendingAction(null);
+      }
+    });
+  }
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      <div
+        className={cn(
+          "flex gap-2",
+          layout === "stacked" ? "flex-col sm:flex-row" : "flex-row flex-wrap"
+        )}
+      >
+        <button
+          type="button"
+          onClick={() => runAction("approve")}
+          disabled={disabled}
+          className={cn(
+            "rounded bg-emerald-600 px-3 py-1 text-xs font-medium text-white shadow-sm transition hover:bg-emerald-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600",
+            (disabled && pendingAction !== "approve") || (pendingAction === "approve" && isPending)
+              ? "opacity-80"
+              : undefined
+          )}
+        >
+          {pendingAction === "approve" && (isPending || pendingAction)
+            ? "Approving…"
+            : "Approve"}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            if (typeof window !== "undefined") {
+              const confirmed = window.confirm("Reject this project?");
+              if (!confirmed) {
+                setPendingAction(null);
+                return;
+              }
+              const reason = window.prompt("Reason for rejection (optional)")?.trim();
+              runAction("reject", reason ? { reason } : undefined);
+              return;
+            }
+            runAction("reject");
+          }}
+          disabled={disabled}
+          className={cn(
+            "rounded bg-rose-600 px-3 py-1 text-xs font-medium text-white shadow-sm transition hover:bg-rose-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-rose-600",
+            (disabled && pendingAction !== "reject") || (pendingAction === "reject" && isPending)
+              ? "opacity-80"
+              : undefined
+          )}
+        >
+          {pendingAction === "reject" && (isPending || pendingAction)
+            ? "Rejecting…"
+            : "Reject"}
+        </button>
+      </div>
+      {message ? (
+        <p
+          className={cn(
+            "text-xs", 
+            message.kind === "success" ? "text-emerald-600" : "text-rose-600"
+          )}
+        >
+          {message.text}
+        </p>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add an admin dashboard index that links to project approvals and other tools
- rebuild the pending projects table with inline approve/reject actions and richer metadata
- expand the project detail view and expose JSON APIs for approving or rejecting submissions
- normalize joined profile data so the approvals list and detail pages receive a single creator profile object
- fix the admin project approval/rejection API validation to use supported Zod error fields so type checks pass

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e28523cc1c83268d1beb211fdf65f6